### PR TITLE
feat: pinned-column + sticky-header shadows, scrollProps wrapper, generalized borders

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ The component supports context menus via Mantine’s `Menu` component, column vi
 
 All dimension and typography props (`height`, `width`, spacing, font size/weight) support **responsive breakpoint values** via Mantine's `StyleProp`, resolved purely through CSS media queries with zero JavaScript re-renders.
 
-It provides fine-grained typography control — via ellipsis and noWrap — and allows distinct header vs. cell presentation using cellStyle. It supports wide datasets through Table.ScrollContainer for horizontal scrolling, with optional sticky identifier columns, and works seamlessly inside ScrollArea with sticky headers and adjustable offsets.
+It provides fine-grained typography control — via ellipsis and noWrap — and allows distinct header vs. cell presentation using cellStyle. It supports wide datasets through the built-in `scrollProps` API (or `Table.ScrollContainer`) for horizontal scrolling, with optional sticky identifier columns. Pinned columns and `stickyHeader` both ship with subtle drop-shadow indicators that fade in only while there is content scrolled past the edge — a clear visual cue inspired by spreadsheet-style data grids — and the component works seamlessly inside `ScrollArea` with adjustable sticky header offsets.
+
+The outer wrapper also exposes `withTableBorder`, `borderRadius`, and `borderWidth` props: the border is rendered on the non-scrolling outer container so it stays fixed at the edges regardless of horizontal/vertical scroll, even with sticky columns and rounded corners.
 
 For UX polish, it ships with configurable loading overlays (including custom loaders) and rich empty states ranging from simple messages to fully styled components with actions. These features make ListViewTable ideal for applications that need a clear, scalable, and highly interactive tabular list experience.
 

--- a/docs/demos/ListViewTable.demo.configurator.tsx
+++ b/docs/demos/ListViewTable.demo.configurator.tsx
@@ -210,6 +210,14 @@ export const configurator: MantineDemo = {
       libraryValue: 'sm',
     },
     {
+      prop: 'borderWidth',
+      type: 'number',
+      initialValue: 1,
+      libraryValue: 1,
+      min: 0,
+      max: 8,
+    },
+    {
       prop: 'verticalAlign',
       type: 'select',
       data: [

--- a/docs/demos/ListViewTable.demo.configurator.tsx
+++ b/docs/demos/ListViewTable.demo.configurator.tsx
@@ -204,6 +204,12 @@ export const configurator: MantineDemo = {
       libraryValue: 'xs',
     },
     {
+      prop: 'borderRadius',
+      type: 'size',
+      initialValue: 'sm',
+      libraryValue: 'sm',
+    },
+    {
       prop: 'verticalAlign',
       type: 'select',
       data: [

--- a/docs/demos/ListViewTable.demo.pinnedColumns.tsx
+++ b/docs/demos/ListViewTable.demo.pinnedColumns.tsx
@@ -1,5 +1,5 @@
 import { ListViewTable } from '@gfazioli/mantine-list-view-table';
-import { Badge, Table, Text } from '@mantine/core';
+import { Badge, Text } from '@mantine/core';
 import { MantineDemo } from '@mantinex/demo';
 import { dataFilesExtended } from './data-files-extended';
 
@@ -54,22 +54,22 @@ const columns = [
 
 function Demo() {
   return (
-    <Table.ScrollContainer minWidth={1300}>
-      <ListViewTable
-        columns={columns}
-        data={dataFilesExtended}
-        rowKey="id"
-        withTableBorder
-        withColumnBorders
-        highlightOnHover
-      />
-    </Table.ScrollContainer>
+    <ListViewTable
+      columns={columns}
+      data={dataFilesExtended}
+      rowKey="id"
+      withTableBorder
+      borderRadius="md"
+      withColumnBorders
+      highlightOnHover
+      scrollProps={{ minWidth: 1300 }}
+    />
   );
 }
 
 const code = `
 import { ListViewTable } from '@gfazioli/mantine-list-view-table';
-import { Badge, Table } from '@mantine/core';
+import { Badge } from '@mantine/core';
 import { data } from './data';
 
 const columns = [
@@ -94,16 +94,18 @@ const columns = [
 
 function Demo() {
   return (
-    <Table.ScrollContainer minWidth={1300}>
-      <ListViewTable
-        columns={columns}
-        data={data}
-        rowKey="id"
-        withTableBorder
-        withColumnBorders
-        highlightOnHover
-      />
-    </Table.ScrollContainer>
+    // Built-in scroll wrapper with a fixed outer border + border-radius —
+    // no need to wrap in Table.ScrollContainer.
+    <ListViewTable
+      columns={columns}
+      data={data}
+      rowKey="id"
+      withTableBorder
+      borderRadius="md"
+      withColumnBorders
+      highlightOnHover
+      scrollProps={{ minWidth: 1300 }}
+    />
   );
 }
 `;

--- a/docs/demos/ListViewTable.demo.pinnedColumns.tsx
+++ b/docs/demos/ListViewTable.demo.pinnedColumns.tsx
@@ -1,0 +1,116 @@
+import { ListViewTable } from '@gfazioli/mantine-list-view-table';
+import { Badge, Table, Text } from '@mantine/core';
+import { MantineDemo } from '@mantinex/demo';
+import { dataFilesExtended } from './data-files-extended';
+
+const columns = [
+  {
+    key: 'name',
+    title: 'Name',
+    sortable: true,
+    width: 200,
+    sticky: 'left' as const,
+  },
+  { key: 'kind', title: 'Kind', sortable: true, width: 140 },
+  { key: 'size', title: 'Size', sortable: true, width: 120 },
+  {
+    key: 'modified',
+    title: 'Modified',
+    sortable: true,
+    width: 180,
+    renderCell: (row: any) => <Badge variant="light">{row.modified}</Badge>,
+  },
+  {
+    key: 'extra1',
+    title: 'Owner',
+    width: 150,
+    renderCell: () => <Text size="sm">Jamie Chen</Text>,
+  },
+  {
+    key: 'extra2',
+    title: 'Tags',
+    width: 150,
+    renderCell: () => <Text size="sm">draft · final</Text>,
+  },
+  {
+    key: 'extra3',
+    title: 'Project',
+    width: 180,
+    renderCell: () => <Text size="sm">Acme Q3 launch</Text>,
+  },
+  {
+    key: 'actions',
+    title: 'Actions',
+    width: 110,
+    sticky: 'right' as const,
+    textAlign: 'center' as const,
+    renderCell: () => (
+      <Badge variant="filled" color="blue">
+        Open
+      </Badge>
+    ),
+  },
+];
+
+function Demo() {
+  return (
+    <Table.ScrollContainer minWidth={1300}>
+      <ListViewTable
+        columns={columns}
+        data={dataFilesExtended}
+        rowKey="id"
+        withTableBorder
+        withColumnBorders
+        highlightOnHover
+      />
+    </Table.ScrollContainer>
+  );
+}
+
+const code = `
+import { ListViewTable } from '@gfazioli/mantine-list-view-table';
+import { Badge, Table } from '@mantine/core';
+import { data } from './data';
+
+const columns = [
+  // Pin the leftmost column to the left edge
+  { key: 'name',     title: 'Name',     width: 200, sticky: 'left' },
+  { key: 'kind',     title: 'Kind',     width: 140 },
+  { key: 'size',     title: 'Size',     width: 120 },
+  { key: 'modified', title: 'Modified', width: 180 },
+  { key: 'extra1',   title: 'Owner',    width: 150 },
+  { key: 'extra2',   title: 'Tags',     width: 150 },
+  { key: 'extra3',   title: 'Project',  width: 180 },
+  // Pin the rightmost column to the right edge
+  {
+    key: 'actions',
+    title: 'Actions',
+    width: 110,
+    sticky: 'right',
+    textAlign: 'center',
+    renderCell: () => <Badge variant="filled" color="blue">Open</Badge>,
+  },
+];
+
+function Demo() {
+  return (
+    <Table.ScrollContainer minWidth={1300}>
+      <ListViewTable
+        columns={columns}
+        data={data}
+        rowKey="id"
+        withTableBorder
+        withColumnBorders
+        highlightOnHover
+      />
+    </Table.ScrollContainer>
+  );
+}
+`;
+
+export const pinnedColumns: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  defaultExpanded: false,
+  code: [{ fileName: 'Demo.tsx', code, language: 'tsx' }],
+};

--- a/docs/demos/ListViewTable.demo.scrollContainer.tsx
+++ b/docs/demos/ListViewTable.demo.scrollContainer.tsx
@@ -1,5 +1,5 @@
 import { ListViewTable } from '@gfazioli/mantine-list-view-table';
-import { Table, Text } from '@mantine/core';
+import { Text } from '@mantine/core';
 import { MantineDemo } from '@mantinex/demo';
 import { columnsFiles } from './columns-files';
 import { dataFilesExtended, dataFilesExtendedCode } from './data-files-extended';
@@ -40,39 +40,38 @@ const columns = [
 
 function Demo() {
   return (
-    <Table.ScrollContainer minWidth={1200}>
-      <ListViewTable
-        columns={columns}
-        data={data}
-        rowKey="id"
-        withTableBorder
-        withColumnBorders
-        highlightOnHover
-        enableColumnResizing={false}
-      />
-    </Table.ScrollContainer>
+    <ListViewTable
+      columns={columns}
+      data={data}
+      rowKey="id"
+      withTableBorder
+      borderRadius="md"
+      withColumnBorders
+      highlightOnHover
+      enableColumnResizing={false}
+      scrollProps={{ minWidth: 1200 }}
+    />
   );
 }
 
 const code = `
 import { ListViewTable } from '@gfazioli/mantine-list-view-table';
-import { Table } from '@mantine/core';
 import { data } from './data';
 import { columns } from './columns';
 
 function Demo() {
   return (
-    <Table.ScrollContainer minWidth={1200}>
-      <ListViewTable
-        columns={columns}
-        data={data}
-        rowKey="id"
-        withTableBorder
-        withColumnBorders
-        highlightOnHover
-        enableColumnResizing={false}
-      />
-    </Table.ScrollContainer>
+    <ListViewTable
+      columns={columns}
+      data={data}
+      rowKey="id"
+      withTableBorder
+      borderRadius="md"
+      withColumnBorders
+      highlightOnHover
+      enableColumnResizing={false}
+      scrollProps={{ minWidth: 1200 }}
+    />
   );
 }
 `;

--- a/docs/demos/ListViewTable.demo.scrollContainerWithSticky.tsx
+++ b/docs/demos/ListViewTable.demo.scrollContainerWithSticky.tsx
@@ -1,5 +1,5 @@
 import { ListViewTable } from '@gfazioli/mantine-list-view-table';
-import { Table, Text } from '@mantine/core';
+import { Text } from '@mantine/core';
 import { MantineDemo } from '@mantinex/demo';
 import { columnsFiles } from './columns-files';
 import { dataFilesExtended, dataFilesExtendedCode } from './data-files-extended';
@@ -33,39 +33,38 @@ const columns = [
 
 function Demo() {
   return (
-    <Table.ScrollContainer minWidth={1200}>
-      <ListViewTable
-        columns={columns}
-        data={data}
-        rowKey="id"
-        withTableBorder
-        withColumnBorders
-        highlightOnHover
-        enableColumnResizing={false}
-      />
-    </Table.ScrollContainer>
+    <ListViewTable
+      columns={columns}
+      data={data}
+      rowKey="id"
+      withTableBorder
+      borderRadius="md"
+      withColumnBorders
+      highlightOnHover
+      enableColumnResizing={false}
+      scrollProps={{ minWidth: 1200 }}
+    />
   );
 }
 
 const code = `
 import { ListViewTable } from '@gfazioli/mantine-list-view-table';
-import { Table } from '@mantine/core';
 import { data } from './data';
 import { columns } from './columns';
 
 function Demo() {
   return (
-    <Table.ScrollContainer minWidth={1200}>
-      <ListViewTable
-        columns={columns}
-        data={data}
-        rowKey="id"
-        withTableBorder
-        withColumnBorders
-        highlightOnHover
-        enableColumnResizing={false}
-      />
-    </Table.ScrollContainer>
+    <ListViewTable
+      columns={columns}
+      data={data}
+      rowKey="id"
+      withTableBorder
+      borderRadius="md"
+      withColumnBorders
+      highlightOnHover
+      enableColumnResizing={false}
+      scrollProps={{ minWidth: 1200 }}
+    />
   );
 }
 `;

--- a/docs/demos/ListViewTable.demo.stylesApi.tsx
+++ b/docs/demos/ListViewTable.demo.stylesApi.tsx
@@ -15,19 +15,14 @@ const data = [
   { id: 9, name: 'Script.js', kind: 'JavaScript File', modified: '2024-06-09' },
 ];
 
-// Two columns are enough to exercise the bulk of the Styles API
-// selectors listed below: a sticky-left first column (renders
-// `stickyColumn` / `stickyHeaderColumn`) plus a regular column with a
-// custom `renderCell`. Reordering renders `dragHandle`,
-// multi-selection plus keyboard nav exercise `selectedRow` /
-// `focusedRow`, and `scrollProps.maxHeight` puts the table inside a
-// vertical `scrollViewport` so the `header` drop shadow can engage on
-// scroll. Column resizing is intentionally *not* enabled here:
-// Chromium ignores explicit `<th>` widths on `position: sticky` cells
-// under `table-layout: fixed`, so the resize handle doesn't reflect
-// the dragged width on this configuration. The other resize-focused
-// demos (`Resize Mode`, `Auto-Fit Columns`, `Configurator`) cover the
-// `resizeHandle` selector instead.
+// Two columns are enough to exercise every Styles API selector listed
+// below: a sticky-left first column (renders `stickyColumn` /
+// `stickyHeaderColumn`) plus a regular column with a custom
+// `renderCell`. Reordering + resizing render `dragHandle` /
+// `resizeHandle`, multi-selection plus keyboard nav exercise
+// `selectedRow` / `focusedRow`, and `scrollProps.maxHeight` puts the
+// table inside a vertical `scrollViewport` so the `header` drop
+// shadow can engage on scroll.
 const columns = [
   {
     key: 'name',
@@ -91,6 +86,7 @@ function Demo() {
         stickyHeader
         selectionMode="multiple"
         enableColumnReordering
+        enableColumnResizing
         scrollProps={{ maxHeight: 280 }}
       />
   );
@@ -109,6 +105,7 @@ function Demo(props: any) {
       stickyHeader
       selectionMode="multiple"
       enableColumnReordering
+      enableColumnResizing
       scrollProps={{ maxHeight: 280 }}
       {...props}
     />

--- a/docs/demos/ListViewTable.demo.stylesApi.tsx
+++ b/docs/demos/ListViewTable.demo.stylesApi.tsx
@@ -1,12 +1,88 @@
 import { ListViewTable } from '@gfazioli/mantine-list-view-table';
+import { Badge, Stack, Text } from '@mantine/core';
 import { MantineDemo } from '@mantinex/demo';
 import { ListViewTableStylesApi } from '../styles-api/ListViewTable.styles-api';
-import { columns } from './columns-three';
-import { data } from './data-files';
+
+const data = [
+  { id: 1, name: 'File.txt', kind: 'Text Document', size: '12 KB', modified: '2024-06-01' },
+  { id: 2, name: 'Image.png', kind: 'PNG Image', size: '2 MB', modified: '2024-06-02' },
+  { id: 3, name: 'Video.mp4', kind: 'MPEG-4 Movie', size: '125 MB', modified: '2024-06-03' },
+  { id: 4, name: 'Document.pdf', kind: 'PDF Document', size: '500 KB', modified: '2024-06-04' },
+  { id: 5, name: 'Archive.zip', kind: 'ZIP Archive', size: '1.5 GB', modified: '2024-06-05' },
+  {
+    id: 6,
+    name: 'Spreadsheet.xlsx',
+    kind: 'Excel Spreadsheet',
+    size: '300 KB',
+    modified: '2024-06-06',
+  },
+  { id: 7, name: 'Presentation.pptx', kind: 'PowerPoint', size: '2 MB', modified: '2024-06-07' },
+];
+
+// Enabling the full feature set so every Styles API selector / modifier
+// listed below is actually rendered: `dragHandle` (column reordering),
+// `resizeHandle` (column resizing), `stickyColumn` /
+// `stickyHeaderColumn` (a pinned column), `scrollViewport`
+// (`scrollProps` wrapper), `selectedRow` and `focusedRow` (selection +
+// keyboard navigation), `header` drop shadow (`stickyHeader`).
+const columns = [
+  {
+    key: 'name',
+    title: 'Name',
+    sortable: true,
+    width: 220,
+    sticky: 'left' as const,
+    renderCell: (row: any) => (
+      <Stack gap={0}>
+        <Text size="sm" fw={500}>
+          {row.name}
+        </Text>
+        <Text size="xs" c="dimmed">
+          {row.kind}
+        </Text>
+      </Stack>
+    ),
+  },
+  { key: 'kind', title: 'Kind', sortable: true, width: 220 },
+  { key: 'size', title: 'Size', sortable: true, textAlign: 'right' as const, width: 200 },
+  {
+    key: 'modified',
+    title: 'Modified',
+    sortable: true,
+    width: 220,
+    renderCell: (row: any) => <Badge variant="light">{row.modified}</Badge>,
+  },
+];
 
 const code = `
 import { ListViewTable } from "@gfazioli/mantine-list-view-table";
+import { Badge, Stack, Text } from '@mantine/core';
 import { data } from './data';
+
+const columns = [
+  {
+    key: 'name',
+    title: 'Name',
+    sortable: true,
+    width: 220,
+    sticky: 'left',
+    renderCell: (row) => (
+      <Stack gap={0}>
+        <Text size="sm" fw={500}>{row.name}</Text>
+        <Text size="xs" c="dimmed">{row.kind}</Text>
+      </Stack>
+    ),
+  },
+  { key: 'kind', title: 'Kind', sortable: true, width: 220 },
+  { key: 'size', title: 'Size', sortable: true, textAlign: 'right', width: 200 },
+  {
+    key: 'modified',
+    title: 'Modified',
+    sortable: true,
+    width: 220,
+    renderCell: (row) => <Badge variant="light">{row.modified}</Badge>,
+  },
+];
 
 function Demo() {
   return (
@@ -14,13 +90,36 @@ function Demo() {
         columns={columns}
         data={data}
         rowKey="id"
+        withTableBorder
+        borderRadius="md"
+        highlightOnHover
+        stickyHeader
+        selectionMode="multiple"
+        enableColumnReordering
+        enableColumnResizing
+        scrollProps={{ minWidth: 800, maxHeight: 320 }}
       />
   );
 }
 `;
 
 function Demo(props: any) {
-  return <ListViewTable columns={columns} data={data} rowKey="id" {...props} />;
+  return (
+    <ListViewTable
+      columns={columns}
+      data={data}
+      rowKey="id"
+      withTableBorder
+      borderRadius="md"
+      highlightOnHover
+      stickyHeader
+      selectionMode="multiple"
+      enableColumnReordering
+      enableColumnResizing
+      scrollProps={{ minWidth: 800, maxHeight: 320 }}
+      {...props}
+    />
+  );
 }
 
 export const stylesApi: MantineDemo = {

--- a/docs/demos/ListViewTable.demo.stylesApi.tsx
+++ b/docs/demos/ListViewTable.demo.stylesApi.tsx
@@ -4,33 +4,30 @@ import { MantineDemo } from '@mantinex/demo';
 import { ListViewTableStylesApi } from '../styles-api/ListViewTable.styles-api';
 
 const data = [
-  { id: 1, name: 'File.txt', kind: 'Text Document', size: '12 KB', modified: '2024-06-01' },
-  { id: 2, name: 'Image.png', kind: 'PNG Image', size: '2 MB', modified: '2024-06-02' },
-  { id: 3, name: 'Video.mp4', kind: 'MPEG-4 Movie', size: '125 MB', modified: '2024-06-03' },
-  { id: 4, name: 'Document.pdf', kind: 'PDF Document', size: '500 KB', modified: '2024-06-04' },
-  { id: 5, name: 'Archive.zip', kind: 'ZIP Archive', size: '1.5 GB', modified: '2024-06-05' },
-  {
-    id: 6,
-    name: 'Spreadsheet.xlsx',
-    kind: 'Excel Spreadsheet',
-    size: '300 KB',
-    modified: '2024-06-06',
-  },
-  { id: 7, name: 'Presentation.pptx', kind: 'PowerPoint', size: '2 MB', modified: '2024-06-07' },
+  { id: 1, name: 'File.txt', kind: 'Text Document', modified: '2024-06-01' },
+  { id: 2, name: 'Image.png', kind: 'PNG Image', modified: '2024-06-02' },
+  { id: 3, name: 'Video.mp4', kind: 'MPEG-4 Movie', modified: '2024-06-03' },
+  { id: 4, name: 'Document.pdf', kind: 'PDF Document', modified: '2024-06-04' },
+  { id: 5, name: 'Archive.zip', kind: 'ZIP Archive', modified: '2024-06-05' },
+  { id: 6, name: 'Spreadsheet.xlsx', kind: 'Excel Spreadsheet', modified: '2024-06-06' },
+  { id: 7, name: 'Presentation.pptx', kind: 'PowerPoint', modified: '2024-06-07' },
+  { id: 8, name: 'Audio.mp3', kind: 'MP3 Audio', modified: '2024-06-08' },
+  { id: 9, name: 'Script.js', kind: 'JavaScript File', modified: '2024-06-09' },
 ];
 
-// Enabling the full feature set so every Styles API selector / modifier
-// listed below is actually rendered: `dragHandle` (column reordering),
-// `resizeHandle` (column resizing), `stickyColumn` /
-// `stickyHeaderColumn` (a pinned column), `scrollViewport`
-// (`scrollProps` wrapper), `selectedRow` and `focusedRow` (selection +
-// keyboard navigation), `header` drop shadow (`stickyHeader`).
+// Two columns are enough to exercise every Styles API selector listed
+// below: a sticky-left first column (renders `stickyColumn` /
+// `stickyHeaderColumn`) plus a regular column with a custom
+// `renderCell`. Reordering + resizing render `dragHandle` /
+// `resizeHandle`, multi-selection plus keyboard nav exercise
+// `selectedRow` / `focusedRow`, and `scrollProps.maxHeight` puts the
+// table inside a vertical `scrollViewport` so the `header` drop shadow
+// can engage on scroll.
 const columns = [
   {
     key: 'name',
     title: 'Name',
     sortable: true,
-    width: 220,
     sticky: 'left' as const,
     renderCell: (row: any) => (
       <Stack gap={0}>
@@ -43,13 +40,10 @@ const columns = [
       </Stack>
     ),
   },
-  { key: 'kind', title: 'Kind', sortable: true, width: 220 },
-  { key: 'size', title: 'Size', sortable: true, textAlign: 'right' as const, width: 200 },
   {
     key: 'modified',
     title: 'Modified',
     sortable: true,
-    width: 220,
     renderCell: (row: any) => <Badge variant="light">{row.modified}</Badge>,
   },
 ];
@@ -64,7 +58,6 @@ const columns = [
     key: 'name',
     title: 'Name',
     sortable: true,
-    width: 220,
     sticky: 'left',
     renderCell: (row) => (
       <Stack gap={0}>
@@ -73,13 +66,10 @@ const columns = [
       </Stack>
     ),
   },
-  { key: 'kind', title: 'Kind', sortable: true, width: 220 },
-  { key: 'size', title: 'Size', sortable: true, textAlign: 'right', width: 200 },
   {
     key: 'modified',
     title: 'Modified',
     sortable: true,
-    width: 220,
     renderCell: (row) => <Badge variant="light">{row.modified}</Badge>,
   },
 ];
@@ -97,7 +87,7 @@ function Demo() {
         selectionMode="multiple"
         enableColumnReordering
         enableColumnResizing
-        scrollProps={{ minWidth: 800, maxHeight: 320 }}
+        scrollProps={{ maxHeight: 280 }}
       />
   );
 }
@@ -116,7 +106,7 @@ function Demo(props: any) {
       selectionMode="multiple"
       enableColumnReordering
       enableColumnResizing
-      scrollProps={{ minWidth: 800, maxHeight: 320 }}
+      scrollProps={{ maxHeight: 280 }}
       {...props}
     />
   );

--- a/docs/demos/ListViewTable.demo.stylesApi.tsx
+++ b/docs/demos/ListViewTable.demo.stylesApi.tsx
@@ -15,14 +15,19 @@ const data = [
   { id: 9, name: 'Script.js', kind: 'JavaScript File', modified: '2024-06-09' },
 ];
 
-// Two columns are enough to exercise every Styles API selector listed
-// below: a sticky-left first column (renders `stickyColumn` /
-// `stickyHeaderColumn`) plus a regular column with a custom
-// `renderCell`. Reordering + resizing render `dragHandle` /
-// `resizeHandle`, multi-selection plus keyboard nav exercise
-// `selectedRow` / `focusedRow`, and `scrollProps.maxHeight` puts the
-// table inside a vertical `scrollViewport` so the `header` drop shadow
-// can engage on scroll.
+// Two columns are enough to exercise the bulk of the Styles API
+// selectors listed below: a sticky-left first column (renders
+// `stickyColumn` / `stickyHeaderColumn`) plus a regular column with a
+// custom `renderCell`. Reordering renders `dragHandle`,
+// multi-selection plus keyboard nav exercise `selectedRow` /
+// `focusedRow`, and `scrollProps.maxHeight` puts the table inside a
+// vertical `scrollViewport` so the `header` drop shadow can engage on
+// scroll. Column resizing is intentionally *not* enabled here:
+// Chromium ignores explicit `<th>` widths on `position: sticky` cells
+// under `table-layout: fixed`, so the resize handle doesn't reflect
+// the dragged width on this configuration. The other resize-focused
+// demos (`Resize Mode`, `Auto-Fit Columns`, `Configurator`) cover the
+// `resizeHandle` selector instead.
 const columns = [
   {
     key: 'name',
@@ -86,7 +91,6 @@ function Demo() {
         stickyHeader
         selectionMode="multiple"
         enableColumnReordering
-        enableColumnResizing
         scrollProps={{ maxHeight: 280 }}
       />
   );
@@ -105,7 +109,6 @@ function Demo(props: any) {
       stickyHeader
       selectionMode="multiple"
       enableColumnReordering
-      enableColumnResizing
       scrollProps={{ maxHeight: 280 }}
       {...props}
     />

--- a/docs/demos/index.ts
+++ b/docs/demos/index.ts
@@ -21,6 +21,7 @@ export { maxWidth } from './ListViewTable.demo.maxWidth';
 export { minAndMaxWidth } from './ListViewTable.demo.minAndMaxWidth';
 export { minWidth } from './ListViewTable.demo.minWidth';
 export { mixedWidthConstraints } from './ListViewTable.demo.mixedWidthConstraints';
+export { pinnedColumns } from './ListViewTable.demo.pinnedColumns';
 export { reordering } from './ListViewTable.demo.reordering';
 export { resizeMode } from './ListViewTable.demo.resizeMode';
 export { responsiveProps } from './ListViewTable.demo.responsiveProps';

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -53,6 +53,31 @@ You can also use the `stickyHeaderOffset` prop to adjust the sticky header posit
 
 <Demo data={demos.stickyHeader} />
 
+## Pinned Columns
+
+Set `column.sticky` to `'left'` or `'right'` to pin a column to the corresponding edge of the table when the user scrolls horizontally. The legacy `sticky: true` is preserved as an alias for `'left'`.
+
+A subtle gradient shadow appears on the inner edge of the **last** sticky-left column and the **first** sticky-right column whenever there is content scrolled past the edge — the same visual cue users expect from spreadsheet-style data grids. The shadow fades out smoothly when the table is scrolled fully to the relevant side, and is hidden entirely on tables that fit within the viewport.
+
+The shadow is rendered as a real `<span>` element exposed via the `stickyColumnShadow` Styles API selector, and its opacity is driven by two CSS variables (`--lvt-shadow-left-opacity` / `--lvt-shadow-right-opacity`) that the internal `useStickyShadow` hook updates on horizontal scroll — **no React re-renders** during scroll.
+
+Customize via:
+
+- `--lvt-shadow-color` — gradient color (default `rgba(0, 0, 0, 0.15)` light / `rgba(0, 0, 0, 0.4)` dark)
+- `--lvt-shadow-width` — width of the shadow strip (default `4px`)
+
+```tsx
+const columns = [
+  { key: 'name', title: 'Name', width: 200, sticky: 'left' },
+  { key: 'kind', title: 'Kind', width: 140 },
+  { key: 'size', title: 'Size', width: 120 },
+  // …more columns…
+  { key: 'actions', title: 'Actions', width: 110, sticky: 'right' },
+];
+```
+
+<Demo data={demos.pinnedColumns} />
+
 ## Row Selection
 
 The `ListViewTable` component supports row selection with both single and multiple selection modes, inspired by macOS Finder behavior.

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -271,19 +271,19 @@ The `cellStyle` property can be either a static style object or a function that 
 
 This approach is particularly useful when building data-heavy interfaces where header clarity and cell readability have different requirements.
 
-## Horizontal Scrolling with Table.ScrollContainer
+## Horizontal Scrolling
 
-When your table content is wider than the available container width, you can use Mantine's [`Table.ScrollContainer`](https://mantine.dev/core/table/#scroll-container) component to enable smooth horizontal scrolling. This is especially useful for tables with many columns or when you need to maintain fixed column widths.
+When your table content is wider than the available container width, set `scrollProps={{ minWidth }}` to enable smooth horizontal scrolling. The recommended pattern is the built-in `scrollProps` API: it renders a non-scrolling outer wrapper that keeps `withTableBorder` and `borderRadius` fixed at the edges regardless of scroll position. Mantine's [`Table.ScrollContainer`](https://mantine.dev/core/table/#scroll-container) is also supported (just wrap `<ListViewTable>`), but the table border will move with the scroll content — see the **Pinned Columns** section above for the trade-off.
 
 ### Basic Horizontal Scrolling
 
-Wrap your `ListViewTable` with `Table.ScrollContainer` and set a `minWidth` to enable horizontal scrolling when the content exceeds the container width. All columns will scroll together horizontally.
+Set `scrollProps={{ minWidth }}` to enable horizontal scrolling when the content exceeds the container width. All non-sticky columns scroll together horizontally; the outer border and rounded corners stay put.
 
 <Demo data={demos.scrollContainer} />
 
 ### Horizontal Scrolling with Sticky Columns
 
-You can combine horizontal scrolling with sticky columns to keep important identifier columns (like names or IDs) visible while other columns scroll horizontally. Set `sticky: true` on the columns you want to remain fixed.
+Combine `scrollProps` with `sticky: 'left'` (or `'right'`) on individual columns to keep important identifier columns visible while other columns scroll horizontally. The legacy `sticky: true` is preserved as an alias for `'left'`.
 
 <Demo data={demos.scrollContainerWithSticky} />
 

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -51,13 +51,15 @@ The sticky header feature works both with the document scroll and when the table
 
 You can also use the `stickyHeaderOffset` prop to adjust the sticky header position when your page has a fixed navigation bar or header. This ensures the table header doesn't overlap with other fixed elements on the page.
 
+A subtle drop shadow fades in below the thead while it is stuck at `stickyHeaderOffset` and fades back out when sticky releases — the same visual cue used by spreadsheet apps to signal that content is scrolling underneath. The fade is driven by the `--lvt-header-shadow-opacity` CSS variable, with **no React re-renders** during scroll.
+
 <Demo data={demos.stickyHeader} />
 
 ## Pinned Columns
 
 Set `column.sticky` to `'left'` or `'right'` to pin a column to the corresponding edge of the table when the user scrolls horizontally. The legacy `sticky: true` is preserved as an alias for `'left'`.
 
-A subtle gradient shadow (`::after` pseudo-element on the cell) appears on the inner edge of the **last** sticky-left column and the **first** sticky-right column whenever there is content scrolled past the edge — the same visual cue users expect from spreadsheet-style data grids. The shadow fades smoothly when the table is scrolled fully to the relevant side and is hidden entirely on tables that fit within the viewport. Opacity is driven by `--lvt-shadow-left-opacity` / `--lvt-shadow-right-opacity` CSS variables that the internal `useStickyShadow` hook updates on horizontal scroll — **no React re-renders** during scroll.
+A subtle gradient shadow (`::after` pseudo-element on the cell) appears on the inner edge of the **last** sticky-left column and the **first** sticky-right column whenever there is content scrolled past the edge — the same visual cue users expect from spreadsheet-style data grids. The shadow fades smoothly when the table is scrolled fully to the relevant side and is hidden entirely on tables that fit within the viewport. Opacity is driven by `--lvt-shadow-left-opacity` / `--lvt-shadow-right-opacity` CSS variables that the internal `useStickyShadow` hook updates on horizontal scroll — **no React re-renders** during scroll. The shadow color and width can be customized via `--lvt-shadow-color` and `--lvt-shadow-width`.
 
 ```tsx
 const columns = [
@@ -68,9 +70,11 @@ const columns = [
 ];
 ```
 
-### Recommended setup with scrollProps
+<Demo data={demos.pinnedColumns} />
 
-When combining sticky columns with `withTableBorder` and/or `borderRadius`, prefer the built-in `scrollProps` over `Mantine.Table.ScrollContainer`. The `scrollProps` API tells `ListViewTable` to render its own scroll wrapper, with the **outer container non-scrolling** — the border and rounded corners stay fixed regardless of scroll position. With `Table.ScrollContainer`, the entire table (including its border) is translated during scroll, so the outer borders briefly disappear at the edges.
+## Horizontal Scrolling
+
+When your table content is wider than the available container width, set `scrollProps={{ minWidth }}` to enable smooth horizontal scrolling. The recommended pattern is the built-in `scrollProps` API: it renders a non-scrolling outer wrapper that keeps `withTableBorder`, `borderRadius`, and `borderWidth` fixed at the edges regardless of scroll position. This is especially important when combining horizontal scroll with **sticky columns** — Mantine's [`Table.ScrollContainer`](https://mantine.dev/core/table/#scroll-container) is also supported (just wrap `<ListViewTable>`), but the table border will move with the scroll content because the entire table is translated during scroll.
 
 ```tsx
 <ListViewTable
@@ -88,9 +92,27 @@ When combining sticky columns with `withTableBorder` and/or `borderRadius`, pref
 - `minWidth?: number | string` — minimum width that forces horizontal scroll
 - `maxHeight?: number | string` — maximum height that enables vertical scroll
 
-If both `scrollProps` and an outer `Table.ScrollContainer` are used, `scrollProps` wins — the table will scroll inside its own viewport. You can omit `scrollProps` and continue using `Table.ScrollContainer`, but the outer borders will move with the table during scroll.
+If both `scrollProps` and an outer `Table.ScrollContainer` are used, `scrollProps` wins — the table will scroll inside its own viewport.
 
-<Demo data={demos.pinnedColumns} />
+### Basic Horizontal Scrolling
+
+Set `scrollProps={{ minWidth }}` to enable horizontal scrolling when the content exceeds the container width. All non-sticky columns scroll together horizontally; the outer border and rounded corners stay put.
+
+<Demo data={demos.scrollContainer} />
+
+### Horizontal Scrolling with Sticky Columns
+
+Combine `scrollProps` with `sticky: 'left'` (or `'right'`) on individual columns to keep important identifier columns visible while other columns scroll horizontally. The legacy `sticky: true` is preserved as an alias for `'left'`.
+
+<Demo data={demos.scrollContainerWithSticky} />
+
+## Scroll Area Integration
+
+The `ListViewTable` works seamlessly with Mantine's `ScrollArea` component. This is useful when you want to create a fixed-height table with scrollable content while maintaining the table's sticky header functionality.
+
+When used inside a `ScrollArea`, the `stickyHeader` prop will make the table header stick to the top of the scroll area, providing a consistent user experience during scrolling.
+
+<Demo data={demos.scrollArea} />
 
 ## Row Selection
 
@@ -108,7 +130,7 @@ For full control over the selection state, use the `selectedRows` and `onSelecti
 
 <Demo data={demos.controlledSelection} />
 
-## Keyboard Navigation
+### Keyboard Navigation
 
 When `selectionMode` is set, keyboard navigation is automatically enabled. You can also explicitly control it with the `enableKeyboardNavigation` prop.
 
@@ -193,7 +215,7 @@ When column resizing is enabled, double-click on a resize handle to auto-fit the
 The `resizeMode` prop controls how column resizing behaves:
 
 - **`standard`** (default): dragging the resize handle trades width between the left column and its right neighbor. The total table width stays fixed.
-- **`finder`**: dragging only changes the left column width. The table grows or shrinks freely, similar to macOS Finder. Use with `Table.ScrollContainer` for horizontal scrolling when the table exceeds its container.
+- **`finder`**: dragging only changes the left column width. The table grows or shrinks freely, similar to macOS Finder. Use with `scrollProps` (or `Table.ScrollContainer`) for horizontal scrolling when the table exceeds its container.
 
 <Demo data={demos.resizeMode} />
 
@@ -270,30 +292,6 @@ The `cellStyle` property can be either a static style object or a function that 
 - **Consistency**: Maintain header layout while customizing cell presentation
 
 This approach is particularly useful when building data-heavy interfaces where header clarity and cell readability have different requirements.
-
-## Horizontal Scrolling
-
-When your table content is wider than the available container width, set `scrollProps={{ minWidth }}` to enable smooth horizontal scrolling. The recommended pattern is the built-in `scrollProps` API: it renders a non-scrolling outer wrapper that keeps `withTableBorder` and `borderRadius` fixed at the edges regardless of scroll position. Mantine's [`Table.ScrollContainer`](https://mantine.dev/core/table/#scroll-container) is also supported (just wrap `<ListViewTable>`), but the table border will move with the scroll content — see the **Pinned Columns** section above for the trade-off.
-
-### Basic Horizontal Scrolling
-
-Set `scrollProps={{ minWidth }}` to enable horizontal scrolling when the content exceeds the container width. All non-sticky columns scroll together horizontally; the outer border and rounded corners stay put.
-
-<Demo data={demos.scrollContainer} />
-
-### Horizontal Scrolling with Sticky Columns
-
-Combine `scrollProps` with `sticky: 'left'` (or `'right'`) on individual columns to keep important identifier columns visible while other columns scroll horizontally. The legacy `sticky: true` is preserved as an alias for `'left'`.
-
-<Demo data={demos.scrollContainerWithSticky} />
-
-## Scroll Area Integration
-
-The `ListViewTable` works seamlessly with Mantine's `ScrollArea` component. This is useful when you want to create a fixed-height table with scrollable content while maintaining the table's sticky header functionality.
-
-When used inside a `ScrollArea`, the `stickyHeader` prop will make the table header stick to the top of the scroll area, providing a consistent user experience during scrolling.
-
-<Demo data={demos.scrollArea} />
 
 ## Table States
 

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -57,24 +57,38 @@ You can also use the `stickyHeaderOffset` prop to adjust the sticky header posit
 
 Set `column.sticky` to `'left'` or `'right'` to pin a column to the corresponding edge of the table when the user scrolls horizontally. The legacy `sticky: true` is preserved as an alias for `'left'`.
 
-A subtle gradient shadow appears on the inner edge of the **last** sticky-left column and the **first** sticky-right column whenever there is content scrolled past the edge — the same visual cue users expect from spreadsheet-style data grids. The shadow fades out smoothly when the table is scrolled fully to the relevant side, and is hidden entirely on tables that fit within the viewport.
-
-The shadow is rendered as a real `<span>` element exposed via the `stickyColumnShadow` Styles API selector, and its opacity is driven by two CSS variables (`--lvt-shadow-left-opacity` / `--lvt-shadow-right-opacity`) that the internal `useStickyShadow` hook updates on horizontal scroll — **no React re-renders** during scroll.
-
-Customize via:
-
-- `--lvt-shadow-color` — gradient color (default `rgba(0, 0, 0, 0.15)` light / `rgba(0, 0, 0, 0.4)` dark)
-- `--lvt-shadow-width` — width of the shadow strip (default `4px`)
+A subtle gradient shadow (`::after` pseudo-element on the cell) appears on the inner edge of the **last** sticky-left column and the **first** sticky-right column whenever there is content scrolled past the edge — the same visual cue users expect from spreadsheet-style data grids. The shadow fades smoothly when the table is scrolled fully to the relevant side and is hidden entirely on tables that fit within the viewport. Opacity is driven by `--lvt-shadow-left-opacity` / `--lvt-shadow-right-opacity` CSS variables that the internal `useStickyShadow` hook updates on horizontal scroll — **no React re-renders** during scroll.
 
 ```tsx
 const columns = [
   { key: 'name', title: 'Name', width: 200, sticky: 'left' },
   { key: 'kind', title: 'Kind', width: 140 },
-  { key: 'size', title: 'Size', width: 120 },
   // …more columns…
   { key: 'actions', title: 'Actions', width: 110, sticky: 'right' },
 ];
 ```
+
+### Recommended setup with scrollProps
+
+When combining sticky columns with `withTableBorder` and/or `borderRadius`, prefer the built-in `scrollProps` over `Mantine.Table.ScrollContainer`. The `scrollProps` API tells `ListViewTable` to render its own scroll wrapper, with the **outer container non-scrolling** — the border and rounded corners stay fixed regardless of scroll position. With `Table.ScrollContainer`, the entire table (including its border) is translated during scroll, so the outer borders briefly disappear at the edges.
+
+```tsx
+<ListViewTable
+  columns={columns}
+  data={data}
+  rowKey="id"
+  withTableBorder
+  borderRadius="md"
+  scrollProps={{ minWidth: 1300 /* enable horizontal scroll when content is wider */ }}
+/>
+```
+
+`scrollProps` accepts:
+
+- `minWidth?: number | string` — minimum width that forces horizontal scroll
+- `maxHeight?: number | string` — maximum height that enables vertical scroll
+
+If both `scrollProps` and an outer `Table.ScrollContainer` are used, `scrollProps` wins — the table will scroll inside its own viewport. You can omit `scrollProps` and continue using `Table.ScrollContainer`, but the outer borders will move with the table during scroll.
 
 <Demo data={demos.pinnedColumns} />
 

--- a/docs/styles-api/ListViewTable.styles-api.ts
+++ b/docs/styles-api/ListViewTable.styles-api.ts
@@ -18,6 +18,8 @@ export const ListViewTableStylesApi: StylesApiData<ListViewTableFactory> = {
     selectedRow: 'Selected row highlight',
     focusedRow: 'Focused row outline (keyboard navigation)',
     stickyColumn: 'Sticky column cell (td)',
+    stickyColumnShadow:
+      'Gradient shadow rendered on the inner edge of the last sticky-left and first sticky-right cell, fading in when there is content scrolled past the edge',
     stickyHeaderColumn: 'Sticky header column cell (th)',
     emptyState: 'Empty state container when no data',
     loader: 'Loading state container',
@@ -40,6 +42,13 @@ export const ListViewTableStylesApi: StylesApiData<ListViewTableFactory> = {
         'Controls font weight of cell content – supports responsive values',
       '--list-view-selected-row-color': 'Controls background color of selected rows',
       '--list-view-sticky-blur': 'Controls blur amount for sticky column overlay',
+      '--lvt-shadow-color':
+        'Color of the sticky-column gradient shadow. Default: `rgba(0, 0, 0, 0.15)` (light) / `rgba(0, 0, 0, 0.4)` (dark)',
+      '--lvt-shadow-width': 'Width of the sticky-column gradient shadow in px. Default: `4px`',
+      '--lvt-shadow-left-opacity':
+        'Opacity of the left-side shadow. Driven automatically by `useStickyShadow` based on horizontal scroll position',
+      '--lvt-shadow-right-opacity':
+        'Opacity of the right-side shadow. Driven automatically by `useStickyShadow` based on horizontal scroll position',
     },
   },
 
@@ -83,6 +92,22 @@ export const ListViewTableStylesApi: StylesApiData<ListViewTableFactory> = {
       selector: 'headerCell',
       modifier: 'data-drag-over',
       condition: 'column is drag target',
+    },
+    {
+      selector: 'headerCell',
+      modifier: 'data-sticky-side',
+      condition: '`"left"` or `"right"` when the column is pinned',
+    },
+    {
+      selector: 'cell',
+      modifier: 'data-sticky-side',
+      condition: '`"left"` or `"right"` when the column is pinned',
+    },
+    {
+      selector: 'stickyColumnShadow',
+      modifier: 'data-side',
+      condition:
+        '`"left"` (shadow on right edge of pinned-left) or `"right"` (shadow on left edge of pinned-right)',
     },
   ],
 };

--- a/docs/styles-api/ListViewTable.styles-api.ts
+++ b/docs/styles-api/ListViewTable.styles-api.ts
@@ -18,8 +18,6 @@ export const ListViewTableStylesApi: StylesApiData<ListViewTableFactory> = {
     selectedRow: 'Selected row highlight',
     focusedRow: 'Focused row outline (keyboard navigation)',
     stickyColumn: 'Sticky column cell (td)',
-    stickyColumnShadow:
-      'Gradient shadow rendered on the inner edge of the last sticky-left and first sticky-right cell, fading in when there is content scrolled past the edge',
     stickyHeaderColumn: 'Sticky header column cell (th)',
     emptyState: 'Empty state container when no data',
     loader: 'Loading state container',
@@ -103,10 +101,14 @@ export const ListViewTableStylesApi: StylesApiData<ListViewTableFactory> = {
       condition: '`"left"` or `"right"` when the column is pinned',
     },
     {
-      selector: 'stickyColumnShadow',
-      modifier: 'data-side',
-      condition:
-        '`"left"` (shadow on right edge of pinned-left) or `"right"` (shadow on left edge of pinned-right)',
+      selector: 'cell',
+      modifier: 'data-sticky-shadow',
+      condition: '`"left"` on the last sticky-left cell, `"right"` on the first sticky-right cell',
+    },
+    {
+      selector: 'headerCell',
+      modifier: 'data-sticky-shadow',
+      condition: '`"left"` on the last sticky-left cell, `"right"` on the first sticky-right cell',
     },
   ],
 };

--- a/docs/styles-api/ListViewTable.styles-api.ts
+++ b/docs/styles-api/ListViewTable.styles-api.ts
@@ -42,6 +42,8 @@ export const ListViewTableStylesApi: StylesApiData<ListViewTableFactory> = {
       '--list-view-cell-font-weight':
         'Controls font weight of cell content — supports responsive values',
       '--list-view-selected-row-color': 'Controls background color of selected rows',
+      '--lvt-border-color':
+        'Resolved color of the outer wrapper border when `withTableBorder` is set. Set automatically by the `varsResolver` from the `borderColor` prop; override directly to bypass the prop',
       '--lvt-shadow-color':
         'Color of the sticky-column gradient shadow. Default: `rgba(0, 0, 0, 0.05)` (light) / `rgba(0, 0, 0, 0.25)` (dark)',
       '--lvt-shadow-width':

--- a/docs/styles-api/ListViewTable.styles-api.ts
+++ b/docs/styles-api/ListViewTable.styles-api.ts
@@ -41,7 +41,6 @@ export const ListViewTableStylesApi: StylesApiData<ListViewTableFactory> = {
       '--list-view-cell-font-weight':
         'Controls font weight of cell content – supports responsive values',
       '--list-view-selected-row-color': 'Controls background color of selected rows',
-      '--list-view-sticky-blur': 'Controls blur amount for sticky column overlay',
       '--lvt-shadow-color':
         'Color of the sticky-column gradient shadow. Default: `rgba(0, 0, 0, 0.15)` (light) / `rgba(0, 0, 0, 0.4)` (dark)',
       '--lvt-shadow-width': 'Width of the sticky-column gradient shadow in px. Default: `4px`',

--- a/docs/styles-api/ListViewTable.styles-api.ts
+++ b/docs/styles-api/ListViewTable.styles-api.ts
@@ -19,6 +19,8 @@ export const ListViewTableStylesApi: StylesApiData<ListViewTableFactory> = {
     focusedRow: 'Focused row outline (keyboard navigation)',
     stickyColumn: 'Sticky column cell (td)',
     stickyHeaderColumn: 'Sticky header column cell (th)',
+    scrollViewport:
+      'Internal scroll wrapper rendered when `scrollProps` is set; carries the native horizontal/vertical scroll while the outer container holds the (fixed) border and border-radius',
     emptyState: 'Empty state container when no data',
     loader: 'Loading state container',
   },

--- a/docs/styles-api/ListViewTable.styles-api.ts
+++ b/docs/styles-api/ListViewTable.styles-api.ts
@@ -3,51 +3,55 @@ import type { StylesApiData } from '../components/styles-api.types';
 
 export const ListViewTableStylesApi: StylesApiData<ListViewTableFactory> = {
   selectors: {
-    root: 'Root container element',
-    table: 'Table element',
-    header: 'Table header',
-    headerCell: 'Header cell (th)',
-    headerButton: 'Header title button',
+    root: 'Root container element. Owns `withTableBorder`, `borderRadius` and `borderWidth` (border lives here, not on the inner `<table>`)',
+    table: 'Mantine `<table>` element',
+    header:
+      'Table header (`<thead>`). Carries the drop-shadow that fades in via `--lvt-header-shadow-opacity` when `stickyHeader` is engaged',
+    headerCell: 'Header cell (`<th>`)',
+    headerButton: 'Header title button (sortable column trigger)',
     headerTitle: 'Header title text',
     sortIcon: 'Sort direction icon',
     dragHandle: 'Column drag handle icon',
     resizeHandle: 'Column resize handle',
-    body: 'Table body',
-    row: 'Table row (tr)',
-    cell: 'Table cell (td)',
+    body: 'Table body (`<tbody>`)',
+    row: 'Table row (`<tr>`)',
+    cell: 'Table cell (`<td>`)',
     selectedRow: 'Selected row highlight',
     focusedRow: 'Focused row outline (keyboard navigation)',
-    stickyColumn: 'Sticky column cell (td)',
-    stickyHeaderColumn: 'Sticky header column cell (th)',
+    stickyColumn: 'Sticky body cell (`<td>`) for a pinned column',
+    stickyHeaderColumn: 'Sticky header cell (`<th>`) for a pinned column',
     scrollViewport:
-      'Internal scroll wrapper rendered when `scrollProps` is set; carries the native horizontal/vertical scroll while the outer container holds the (fixed) border and border-radius',
-    emptyState: 'Empty state container when no data',
+      "Internal wrapper around the `<table>`. When `scrollProps` is set this element becomes the native scroll viewport; otherwise it just carries the `clip-path` that clips the table content to the wrapper's rounded corners while leaving the outer border on `.root` untouched",
+    emptyState: 'Empty state container shown when there is no data',
     loader: 'Loading state container',
   },
 
   vars: {
     root: {
-      '--list-view-height': 'Controls ListView height – supports responsive values',
-      '--list-view-width': 'Controls ListView width – supports responsive values',
+      '--list-view-height': 'Controls ListView height — supports responsive values',
+      '--list-view-width': 'Controls ListView width — supports responsive values',
       '--list-view-horizontal-spacing':
-        'Controls horizontal cell padding – supports responsive values',
-      '--list-view-vertical-spacing': 'Controls vertical cell padding – supports responsive values',
+        'Controls horizontal cell padding — supports responsive values',
+      '--list-view-vertical-spacing': 'Controls vertical cell padding — supports responsive values',
       '--list-view-header-title-font-size':
-        'Controls font size of header titles – supports responsive values',
+        'Controls font size of header titles — supports responsive values',
       '--list-view-header-title-font-weight':
-        'Controls font weight of header titles – supports responsive values',
+        'Controls font weight of header titles — supports responsive values',
       '--list-view-cell-font-size':
-        'Controls font size of cell content – supports responsive values',
+        'Controls font size of cell content — supports responsive values',
       '--list-view-cell-font-weight':
-        'Controls font weight of cell content – supports responsive values',
+        'Controls font weight of cell content — supports responsive values',
       '--list-view-selected-row-color': 'Controls background color of selected rows',
       '--lvt-shadow-color':
-        'Color of the sticky-column gradient shadow. Default: `rgba(0, 0, 0, 0.15)` (light) / `rgba(0, 0, 0, 0.4)` (dark)',
-      '--lvt-shadow-width': 'Width of the sticky-column gradient shadow in px. Default: `4px`',
+        'Color of the sticky-column gradient shadow. Default: `rgba(0, 0, 0, 0.05)` (light) / `rgba(0, 0, 0, 0.25)` (dark)',
+      '--lvt-shadow-width':
+        'Width of the sticky-column gradient shadow. Accepts any CSS length. Default: `8px`',
       '--lvt-shadow-left-opacity':
-        'Opacity of the left-side shadow. Driven automatically by `useStickyShadow` based on horizontal scroll position',
+        '_Internal._ Opacity of the left-side column shadow. Driven automatically by `useStickyShadow` based on horizontal scroll position',
       '--lvt-shadow-right-opacity':
-        'Opacity of the right-side shadow. Driven automatically by `useStickyShadow` based on horizontal scroll position',
+        '_Internal._ Opacity of the right-side column shadow. Driven automatically by `useStickyShadow` based on horizontal scroll position',
+      '--lvt-header-shadow-opacity':
+        '_Internal._ Drives the fade in/out of the sticky-header drop shadow. Set to `1` by `useStickyHeaderShadow` while the thead is stuck at `stickyHeaderOffset`, `0` otherwise. To customize the shadow color/blur/spread, override `.mantine-ListViewTable-header` via `classNames`/`styles`',
     },
   },
 
@@ -55,47 +59,63 @@ export const ListViewTableStylesApi: StylesApiData<ListViewTableFactory> = {
     {
       selector: 'root',
       modifier: 'data-loading',
-      condition: '`loading` prop is set to true',
+      condition: '`loading` prop is set to `true`',
     },
     {
-      selector: 'headerCell',
-      modifier: 'data-sticky',
-      condition: 'column has `sticky` prop set to true',
+      selector: 'root',
+      modifier: 'data-with-table-border',
+      condition: '`withTableBorder` prop is set to `true`',
+    },
+    {
+      selector: 'root',
+      modifier: 'data-with-scroll',
+      condition: '`scrollProps` is provided (the inner viewport becomes a native scroller)',
+    },
+    {
+      selector: 'root',
+      modifier: 'data-dragging',
+      condition: 'a column is currently being dragged',
+    },
+    {
+      selector: 'root',
+      modifier: 'data-resizing',
+      condition: 'a column is currently being resized',
     },
     {
       selector: 'headerCell',
       modifier: 'data-column-key',
-      condition: 'column has `columnKey` prop set',
+      condition: "always set; value mirrors the column's `key`",
     },
     {
-      selector: 'cell',
-      modifier: 'data-sticky',
-      condition: 'column has `sticky` prop set to true',
+      selector: 'headerCell',
+      modifier: 'data-sticky-side',
+      condition: '`"left"` or `"right"` when the column is pinned',
     },
     {
-      selector: 'cell',
-      modifier: 'data-column-key',
-      condition: 'column has `columnKey` prop set',
-    },
-    {
-      selector: 'row',
-      modifier: 'data-selected',
-      condition: 'row is selected (if selection is enabled)',
+      selector: 'headerCell',
+      modifier: 'data-sticky-shadow',
+      condition:
+        '`"left"` on the last sticky-left header cell, `"right"` on the first sticky-right header cell',
     },
     {
       selector: 'headerCell',
       modifier: 'data-dragging',
-      condition: 'column is being dragged',
+      condition: 'this column is the one currently being dragged',
     },
     {
       selector: 'headerCell',
       modifier: 'data-drag-over',
-      condition: 'column is drag target',
+      condition: 'this column is the current drop target during a reorder drag',
     },
     {
       selector: 'headerCell',
-      modifier: 'data-sticky-side',
-      condition: '`"left"` or `"right"` when the column is pinned',
+      modifier: 'data-focused',
+      condition: 'the sortable header button has keyboard focus',
+    },
+    {
+      selector: 'cell',
+      modifier: 'data-column-key',
+      condition: "always set; value mirrors the column's `key`",
     },
     {
       selector: 'cell',
@@ -105,12 +125,18 @@ export const ListViewTableStylesApi: StylesApiData<ListViewTableFactory> = {
     {
       selector: 'cell',
       modifier: 'data-sticky-shadow',
-      condition: '`"left"` on the last sticky-left cell, `"right"` on the first sticky-right cell',
+      condition:
+        '`"left"` on the last sticky-left body cell, `"right"` on the first sticky-right body cell',
     },
     {
-      selector: 'headerCell',
-      modifier: 'data-sticky-shadow',
-      condition: '`"left"` on the last sticky-left cell, `"right"` on the first sticky-right cell',
+      selector: 'row',
+      modifier: 'data-selected',
+      condition: 'row is selected (when `selectionMode` is set)',
+    },
+    {
+      selector: 'row',
+      modifier: 'data-focused',
+      condition: 'row is the current keyboard-navigation focus target',
     },
   ],
 };

--- a/package/src/ListViewTable.module.css
+++ b/package/src/ListViewTable.module.css
@@ -240,35 +240,32 @@
   box-shadow: inset 0 -2px 0 0 var(--mantine-primary-color-filled);
 }
 
-/* Sticky column styles — no !important */
+/*
+ * Sticky column styles.
+ *
+ * Sticky cells render with a fully **opaque** background that matches the
+ * surrounding table body / header so the columns underneath are visually
+ * occluded as the table scrolls horizontally — same behavior as
+ * `mantine-datatable`. No backdrop-filter, no transparency: the only edge
+ * cue is the gradient shadow span (see `.stickyColumnShadow` below).
+ */
 .stickyColumn {
   position: sticky;
   left: 0;
   z-index: 10;
-  background: inherit;
+  background: var(--mantine-color-body);
 }
 
-/* Apply blur effect directly to th and td elements */
-.table th.stickyHeaderColumn::before,
-.table td.stickyColumn::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  width: 100%;
-  backdrop-filter: blur(var(--list-view-sticky-blur, 3px));
-  -webkit-backdrop-filter: blur(var(--list-view-sticky-blur, 3px));
-  z-index: -1;
-  pointer-events: none;
-}
-
-/* Header sticky column */
 .stickyHeaderColumn {
   position: sticky;
   left: 0;
   z-index: 11; /* Higher than body sticky columns */
-  background: inherit;
+  background: var(--mantine-color-body);
+}
+
+[data-mantine-color-scheme='dark'] .stickyColumn,
+[data-mantine-color-scheme='dark'] .stickyHeaderColumn {
+  background: var(--mantine-color-dark-7);
 }
 
 /*

--- a/package/src/ListViewTable.module.css
+++ b/package/src/ListViewTable.module.css
@@ -7,18 +7,21 @@
 
 /*
  * The outer `<Box>` always owns `withTableBorder` (the renderer passes
- * `withTableBorder: false` to Mantine's Table). The border line is drawn
- * here so it stays fixed during horizontal scroll regardless of
- * sticky-column behavior.
+ * `withTableBorder: false` to Mantine's Table). The border lives here
+ * as a real CSS `border` so it stays fixed during horizontal scroll
+ * regardless of sticky-column behavior.
  *
- * The `border-radius` and `clip-path` are set inline by the renderer
- * (they depend on the `borderRadius` prop). We use `clip-path: inset(0
- * round X)` instead of `overflow: hidden` to clip the rounded corners,
- * because `overflow: hidden` would establish a scroll containing block
- * for `position: sticky` descendants — that breaks `stickyHeader` when
- * the user scrolls the page (the thead would stay locked inside `.root`
- * instead of pinning to the viewport). `clip-path` clips visually
- * without affecting sticky positioning.
+ * `border-radius` is set inline by the renderer (it depends on the
+ * `borderRadius` prop). The rounded-corner clipping of the table
+ * content is NOT done on this element — that would either:
+ *   - Use `overflow: hidden` and turn `.root` into a scroll containing
+ *     block, breaking `position: sticky` on the table header, OR
+ *   - Use `clip-path` and antialias-clip the border itself at the
+ *     rounded corners.
+ *
+ * Instead, the inner `.scrollViewport` wrapper takes care of the
+ * `clip-path` so the cells get clipped to the rounded shape while the
+ * border on this element remains untouched.
  */
 .root[data-with-table-border='true'] {
   border: rem(0.0625) solid var(--mantine-color-default-border);

--- a/package/src/ListViewTable.module.css
+++ b/package/src/ListViewTable.module.css
@@ -5,6 +5,33 @@
   outline: none;
 }
 
+/*
+ * When `scrollProps` is set on `<ListViewTable>`, the root `<Box>` becomes
+ * the OUTER non-scrolling container. The native `<table>` border is
+ * disabled (the renderer passes `withTableBorder: false` to Mantine's
+ * Table) and we draw the border here instead, so it stays fixed during
+ * horizontal scroll regardless of sticky-column behavior.
+ *
+ * The border-radius is set inline by the renderer (it depends on the
+ * `borderRadius` prop) — we only handle the border line and the
+ * `overflow: hidden` clip needed to honour the rounded corners.
+ */
+.root[data-with-table-border='true'] {
+  border: rem(0.0625) solid var(--mantine-color-default-border);
+  overflow: hidden;
+}
+
+[data-mantine-color-scheme='dark'] .root[data-with-table-border='true'] {
+  border-color: var(--mantine-color-dark-4);
+}
+
+.scrollViewport {
+  /* Inline `overflow` and `maxHeight` set by the renderer when
+     `scrollProps` is provided; otherwise this element uses
+     `display: contents` and disappears from the layout entirely so the
+     no-internal-scroll case is unaffected. */
+}
+
 .root[data-dragging='true'],
 .root[data-resizing='true'] {
   user-select: none;

--- a/package/src/ListViewTable.module.css
+++ b/package/src/ListViewTable.module.css
@@ -58,10 +58,16 @@
  * The `box-shadow` fades in via `--lvt-header-shadow-opacity` (driven by
  * `useStickyHeaderShadow`) once the thead becomes stuck. The same
  * pattern as the sticky-column shadow: zero CSS rules to enable, no
- * React re-renders during scroll. */
+ * React re-renders during scroll.
+ *
+ * To fully customize the shadow (color, blur, spread) override
+ * `.mantine-ListViewTable-header` via the Styles API (`classNames` /
+ * `styles`) — the `--lvt-header-shadow-opacity` driver continues to
+ * control the fade in/out independently of the shadow shape. */
 .header {
   background: var(--mantine-color-white);
-  box-shadow: 0 rem(4) rem(6) rem(-2) rgb(0 0 0 / calc(0.15 * var(--lvt-header-shadow-opacity, 0)));
+  box-shadow: 0 rem(4) rem(6) rem(-2)
+    rgba(0, 0, 0, calc(0.15 * var(--lvt-header-shadow-opacity, 0)));
   transition: box-shadow 200ms ease;
 }
 
@@ -231,7 +237,7 @@
 [data-mantine-color-scheme='dark'] .header {
   background: var(--mantine-color-dark-7);
   border: none;
-  box-shadow: 0 rem(4) rem(6) rem(-2) rgb(0 0 0 / calc(0.4 * var(--lvt-header-shadow-opacity, 0)));
+  box-shadow: 0 rem(4) rem(6) rem(-2) rgba(0, 0, 0, calc(0.4 * var(--lvt-header-shadow-opacity, 0)));
 }
 
 [data-mantine-color-scheme='dark'] .headerCell {
@@ -346,8 +352,8 @@
 .stickyHeaderColumn[data-sticky-shadow='left']::after {
   right: calc(-1 * var(--lvt-shadow-width, 8px));
   background:
-    linear-gradient(to right, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0)),
-    linear-gradient(to right, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0) 30%);
+    linear-gradient(to right, var(--lvt-shadow-color, rgba(0, 0, 0, 0.05)), transparent),
+    linear-gradient(to right, var(--lvt-shadow-color, rgba(0, 0, 0, 0.05)), transparent 30%);
   opacity: var(--lvt-shadow-left-opacity, 0);
 }
 
@@ -355,21 +361,21 @@
 .stickyHeaderColumn[data-sticky-shadow='right']::after {
   left: calc(-1 * var(--lvt-shadow-width, 8px));
   background:
-    linear-gradient(to left, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0)),
-    linear-gradient(to left, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0) 30%);
+    linear-gradient(to left, var(--lvt-shadow-color, rgba(0, 0, 0, 0.05)), transparent),
+    linear-gradient(to left, var(--lvt-shadow-color, rgba(0, 0, 0, 0.05)), transparent 30%);
   opacity: var(--lvt-shadow-right-opacity, 0);
 }
 
 [data-mantine-color-scheme='dark'] .stickyColumn[data-sticky-shadow='left']::after,
 [data-mantine-color-scheme='dark'] .stickyHeaderColumn[data-sticky-shadow='left']::after {
   background:
-    linear-gradient(to right, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0)),
-    linear-gradient(to right, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0) 30%);
+    linear-gradient(to right, var(--lvt-shadow-color, rgba(0, 0, 0, 0.25)), transparent),
+    linear-gradient(to right, var(--lvt-shadow-color, rgba(0, 0, 0, 0.25)), transparent 30%);
 }
 
 [data-mantine-color-scheme='dark'] .stickyColumn[data-sticky-shadow='right']::after,
 [data-mantine-color-scheme='dark'] .stickyHeaderColumn[data-sticky-shadow='right']::after {
   background:
-    linear-gradient(to left, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0)),
-    linear-gradient(to left, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0) 30%);
+    linear-gradient(to left, var(--lvt-shadow-color, rgba(0, 0, 0, 0.25)), transparent),
+    linear-gradient(to left, var(--lvt-shadow-color, rgba(0, 0, 0, 0.25)), transparent 30%);
 }

--- a/package/src/ListViewTable.module.css
+++ b/package/src/ListViewTable.module.css
@@ -44,7 +44,11 @@
   -webkit-user-select: none;
 }
 
-.root:focus-visible {
+/* Show the wrapper-wide focus ring only while no row is focused yet
+ * (e.g. right after the user tabs into the table). Once arrow keys move
+ * focus into a specific row, that row's `.focusedRow` outline takes
+ * over so we don't end up with two overlapping outlines. */
+.root:focus-visible:not(:has(.focusedRow)) {
   outline: 2px solid var(--mantine-primary-color-filled);
   outline-offset: -2px;
 }

--- a/package/src/ListViewTable.module.css
+++ b/package/src/ListViewTable.module.css
@@ -6,19 +6,22 @@
 }
 
 /*
- * When `scrollProps` is set on `<ListViewTable>`, the root `<Box>` becomes
- * the OUTER non-scrolling container. The native `<table>` border is
- * disabled (the renderer passes `withTableBorder: false` to Mantine's
- * Table) and we draw the border here instead, so it stays fixed during
- * horizontal scroll regardless of sticky-column behavior.
+ * The outer `<Box>` always owns `withTableBorder` (the renderer passes
+ * `withTableBorder: false` to Mantine's Table). The border line is drawn
+ * here so it stays fixed during horizontal scroll regardless of
+ * sticky-column behavior.
  *
- * The border-radius is set inline by the renderer (it depends on the
- * `borderRadius` prop) — we only handle the border line and the
- * `overflow: hidden` clip needed to honour the rounded corners.
+ * The `border-radius` and `clip-path` are set inline by the renderer
+ * (they depend on the `borderRadius` prop). We use `clip-path: inset(0
+ * round X)` instead of `overflow: hidden` to clip the rounded corners,
+ * because `overflow: hidden` would establish a scroll containing block
+ * for `position: sticky` descendants — that breaks `stickyHeader` when
+ * the user scrolls the page (the thead would stay locked inside `.root`
+ * instead of pinning to the viewport). `clip-path` clips visually
+ * without affecting sticky positioning.
  */
 .root[data-with-table-border='true'] {
   border: rem(0.0625) solid var(--mantine-color-default-border);
-  overflow: hidden;
 }
 
 [data-mantine-color-scheme='dark'] .root[data-with-table-border='true'] {

--- a/package/src/ListViewTable.module.css
+++ b/package/src/ListViewTable.module.css
@@ -270,3 +270,40 @@
   z-index: 11; /* Higher than body sticky columns */
   background: inherit;
 }
+
+/*
+ * Sticky column shadow.
+ *
+ * Rendered as a real <span> element inside the *last* sticky-left cell and
+ * the *first* sticky-right cell of each row (header + body). The horizontal
+ * `useStickyShadow` hook writes `--lvt-shadow-left-opacity` /
+ * `--lvt-shadow-right-opacity` on the table root in response to scroll, and
+ * those variables cascade down to fade the shadow in and out without
+ * triggering a React re-render.
+ */
+.stickyColumnShadow {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: var(--lvt-shadow-width, 4px);
+  pointer-events: none;
+  transition: opacity 200ms ease;
+  z-index: 0;
+}
+
+.stickyColumnShadow[data-side='left'] {
+  right: calc(-1 * var(--lvt-shadow-width, 4px));
+  background: linear-gradient(to right, var(--lvt-shadow-color, rgba(0, 0, 0, 0.15)), transparent);
+  opacity: var(--lvt-shadow-left-opacity, 0);
+}
+
+.stickyColumnShadow[data-side='right'] {
+  left: calc(-1 * var(--lvt-shadow-width, 4px));
+  background: linear-gradient(to left, var(--lvt-shadow-color, rgba(0, 0, 0, 0.15)), transparent);
+  opacity: var(--lvt-shadow-right-opacity, 0);
+}
+
+/* Slightly stronger shadow on dark color scheme so it stays visible */
+[data-mantine-color-scheme='dark'] .stickyColumnShadow {
+  --lvt-shadow-color: rgba(0, 0, 0, 0.4);
+}

--- a/package/src/ListViewTable.module.css
+++ b/package/src/ListViewTable.module.css
@@ -24,18 +24,29 @@
  * border on this element remains untouched.
  */
 .root[data-with-table-border='true'] {
-  border: rem(0.0625) solid var(--mantine-color-default-border);
+  /* `--lvt-border-color` is set by the `varsResolver` from the public
+   * `borderColor` prop (resolved through Mantine's `getThemeColor`); we
+   * fall back to the same default border color Mantine's table would
+   * have used so omitting `borderColor` keeps the original look. */
+  border: rem(0.0625) solid var(--lvt-border-color, var(--mantine-color-default-border));
 }
 
 [data-mantine-color-scheme='dark'] .root[data-with-table-border='true'] {
-  border-color: var(--mantine-color-dark-4);
+  border-color: var(--lvt-border-color, var(--mantine-color-dark-4));
 }
 
 .scrollViewport {
-  /* Inline `overflow` and `maxHeight` set by the renderer when
-     `scrollProps` is provided; otherwise this element uses
-     `display: contents` and disappears from the layout entirely so the
-     no-internal-scroll case is unaffected. */
+  /* Always rendered as a real `<div>`. The renderer sets inline styles
+     conditionally:
+       - `overflow: auto` + `maxHeight` when `scrollProps` is provided
+         (this element becomes the native scroll viewport)
+       - `clip-path: inset(0 round X)` when `withTableBorder` is set
+         (clips the table content to the wrapper's rounded corners
+         without making `.root` a scroll containing block, which would
+         break `position: sticky` on the thead)
+     When neither prop is set the element is a transparent block
+     wrapper (no width/height styles) and has no measurable layout
+     impact since the inner `<table>` already fills it. */
 }
 
 .root[data-dragging='true'],

--- a/package/src/ListViewTable.module.css
+++ b/package/src/ListViewTable.module.css
@@ -243,49 +243,31 @@
 /*
  * Sticky column styles.
  *
- * Sticky cells render with a fully **opaque** background that matches the
- * surrounding table body / header so the columns underneath are visually
- * occluded as the table scrolls horizontally — same behavior as
- * `mantine-datatable`. No backdrop-filter, no transparency: the only edge
- * cue is the gradient shadow span (see `.stickyColumnShadow` below).
- */
-/*
  * `position: sticky`, `left`, and `right` are set inline by the renderer so
- * each cell can pick the correct side for its `column.sticky` value. The
- * class only carries the cosmetic concerns (background + z-index) that
- * apply equally to left- and right-pinned cells.
+ * each cell can pick the correct side for its `column.sticky` value.
+ *
+ * Background must be **opaque and explicit** — `<tr>` ships with no
+ * background, so anything `inherit`-based bleeds the scroll content
+ * through the sticky cell. `--lvt-sticky-bg` is exposed so consumers can
+ * theme it without overriding the rule directly; it also feeds the outer
+ * stop of the gradient shadow so the gradient transitions into solid
+ * cell color, not into transparency.
  */
 .stickyColumn {
   z-index: 10;
-  background: var(--mantine-color-body);
+  --lvt-sticky-bg: var(--mantine-color-body);
+  background: var(--lvt-sticky-bg);
 }
 
 .stickyHeaderColumn {
   z-index: 11; /* Higher than body sticky columns */
-  background: var(--mantine-color-body);
+  --lvt-sticky-bg: var(--mantine-color-body);
+  background: var(--lvt-sticky-bg);
 }
 
-/*
- * Background "extension" on the inner edge of the last sticky-left and
- * first sticky-right cell.
- *
- * The gradient shadow span (`.stickyColumnShadow`) fades from opaque
- * shadow-color to transparent on its outer edge. Without this extension
- * the transparent portion would let the underlying scroll content peek
- * through — visible as fragments of letters drifting across the edge as
- * the user scrolls. Adding a sharp `box-shadow` of the cell's own
- * background color creates a 4px-wide opaque strip outside the cell that
- * occludes whatever scrolls underneath, so the gradient fades into the
- * cell's color rather than into bleeding-through content.
- */
-.stickyColumn[data-sticky-shadow='left'],
-.stickyHeaderColumn[data-sticky-shadow='left'] {
-  box-shadow: var(--lvt-shadow-width, 4px) 0 0 0 var(--mantine-color-body);
-}
-
-.stickyColumn[data-sticky-shadow='right'],
-.stickyHeaderColumn[data-sticky-shadow='right'] {
-  box-shadow: calc(-1 * var(--lvt-shadow-width, 4px)) 0 0 0 var(--mantine-color-body);
+[data-mantine-color-scheme='dark'] .stickyColumn,
+[data-mantine-color-scheme='dark'] .stickyHeaderColumn {
+  --lvt-sticky-bg: var(--mantine-color-dark-7);
 }
 
 /*
@@ -308,15 +290,30 @@
   z-index: 0;
 }
 
+/*
+ * Both gradient stops are fully opaque: the inner stop is the shadow color
+ * (darker than the cell), the outer stop is the cell's own background. As
+ * the gradient fades it transitions into solid cell color — never into
+ * transparency — so the underlying scroll content cannot peek through the
+ * shadow strip while it scrolls past.
+ */
 .stickyColumnShadow[data-side='left'] {
   right: calc(-1 * var(--lvt-shadow-width, 4px));
-  background: linear-gradient(to right, var(--lvt-shadow-color, rgba(0, 0, 0, 0.15)), transparent);
+  background: linear-gradient(
+    to right,
+    var(--lvt-shadow-color, rgba(0, 0, 0, 0.15)),
+    var(--lvt-sticky-bg, var(--mantine-color-body))
+  );
   opacity: var(--lvt-shadow-left-opacity, 0);
 }
 
 .stickyColumnShadow[data-side='right'] {
   left: calc(-1 * var(--lvt-shadow-width, 4px));
-  background: linear-gradient(to left, var(--lvt-shadow-color, rgba(0, 0, 0, 0.15)), transparent);
+  background: linear-gradient(
+    to left,
+    var(--lvt-shadow-color, rgba(0, 0, 0, 0.15)),
+    var(--lvt-sticky-bg, var(--mantine-color-body))
+  );
   opacity: var(--lvt-shadow-right-opacity, 0);
 }
 

--- a/package/src/ListViewTable.module.css
+++ b/package/src/ListViewTable.module.css
@@ -241,28 +241,31 @@
 }
 
 /*
- * Sticky column styles.
+ * Sticky column styles — modeled after `mantine-datatable`.
  *
  * `position: sticky`, `left`, and `right` are set inline by the renderer so
- * each cell can pick the correct side for its `column.sticky` value.
+ * each cell can pick the correct side for its `column.sticky` value. The
+ * class only carries the cosmetic concerns that apply equally to left- and
+ * right-pinned cells.
  *
- * Background must be **opaque and explicit** — `<tr>` ships with no
- * background, so anything `inherit`-based bleeds the scroll content
- * through the sticky cell. `--lvt-sticky-bg` is exposed so consumers can
- * theme it without overriding the rule directly; it also feeds the outer
- * stop of the gradient shadow so the gradient transitions into solid
- * cell color, not into transparency.
+ * Background MUST be opaque and explicit — `<tr>` ships with no
+ * background, so `inherit` would let the scroll content bleed through.
+ * `--lvt-sticky-bg` resolves to `--mantine-color-body` and gets a
+ * dark-scheme override below.
  */
 .stickyColumn {
   z-index: 10;
   --lvt-sticky-bg: var(--mantine-color-body);
   background: var(--lvt-sticky-bg);
+  /* Allow the shadow ::after to render outside the cell border. */
+  overflow: visible;
 }
 
 .stickyHeaderColumn {
   z-index: 11; /* Higher than body sticky columns */
   --lvt-sticky-bg: var(--mantine-color-body);
   background: var(--lvt-sticky-bg);
+  overflow: visible;
 }
 
 [data-mantine-color-scheme='dark'] .stickyColumn,
@@ -271,53 +274,52 @@
 }
 
 /*
- * Sticky column shadow.
- *
- * Rendered as a real <span> element inside the *last* sticky-left cell and
- * the *first* sticky-right cell of each row (header + body). The horizontal
- * `useStickyShadow` hook writes `--lvt-shadow-left-opacity` /
- * `--lvt-shadow-right-opacity` on the table root in response to scroll, and
- * those variables cascade down to fade the shadow in and out without
- * triggering a React re-render.
+ * Sticky column shadow — rendered as an `::after` pseudo-element on the
+ * cell carrying `data-sticky-shadow`. Two stacked linear gradients with
+ * a low alpha produce the soft, slightly-doubled shadow look used by
+ * `mantine-datatable`. Opacity is driven by the CSS variables that the
+ * `useStickyShadow` hook updates on horizontal scroll — no React
+ * re-renders during scroll.
  */
-.stickyColumnShadow {
+.stickyColumn[data-sticky-shadow]::after,
+.stickyHeaderColumn[data-sticky-shadow]::after {
+  content: '';
   position: absolute;
   top: 0;
   bottom: 0;
-  width: var(--lvt-shadow-width, 4px);
+  width: var(--lvt-shadow-width, 8px);
   pointer-events: none;
   transition: opacity 200ms ease;
-  z-index: 0;
 }
 
-/*
- * Both gradient stops are fully opaque: the inner stop is the shadow color
- * (darker than the cell), the outer stop is the cell's own background. As
- * the gradient fades it transitions into solid cell color — never into
- * transparency — so the underlying scroll content cannot peek through the
- * shadow strip while it scrolls past.
- */
-.stickyColumnShadow[data-side='left'] {
-  right: calc(-1 * var(--lvt-shadow-width, 4px));
-  background: linear-gradient(
-    to right,
-    var(--lvt-shadow-color, rgba(0, 0, 0, 0.15)),
-    var(--lvt-sticky-bg, var(--mantine-color-body))
-  );
+.stickyColumn[data-sticky-shadow='left']::after,
+.stickyHeaderColumn[data-sticky-shadow='left']::after {
+  right: calc(-1 * var(--lvt-shadow-width, 8px));
+  background:
+    linear-gradient(to right, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0)),
+    linear-gradient(to right, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0) 30%);
   opacity: var(--lvt-shadow-left-opacity, 0);
 }
 
-.stickyColumnShadow[data-side='right'] {
-  left: calc(-1 * var(--lvt-shadow-width, 4px));
-  background: linear-gradient(
-    to left,
-    var(--lvt-shadow-color, rgba(0, 0, 0, 0.15)),
-    var(--lvt-sticky-bg, var(--mantine-color-body))
-  );
+.stickyColumn[data-sticky-shadow='right']::after,
+.stickyHeaderColumn[data-sticky-shadow='right']::after {
+  left: calc(-1 * var(--lvt-shadow-width, 8px));
+  background:
+    linear-gradient(to left, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0)),
+    linear-gradient(to left, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0) 30%);
   opacity: var(--lvt-shadow-right-opacity, 0);
 }
 
-/* Slightly stronger shadow on dark color scheme so it stays visible */
-[data-mantine-color-scheme='dark'] .stickyColumnShadow {
-  --lvt-shadow-color: rgba(0, 0, 0, 0.4);
+[data-mantine-color-scheme='dark'] .stickyColumn[data-sticky-shadow='left']::after,
+[data-mantine-color-scheme='dark'] .stickyHeaderColumn[data-sticky-shadow='left']::after {
+  background:
+    linear-gradient(to right, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0)),
+    linear-gradient(to right, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0) 30%);
+}
+
+[data-mantine-color-scheme='dark'] .stickyColumn[data-sticky-shadow='right']::after,
+[data-mantine-color-scheme='dark'] .stickyHeaderColumn[data-sticky-shadow='right']::after {
+  background:
+    linear-gradient(to left, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0)),
+    linear-gradient(to left, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0) 30%);
 }

--- a/package/src/ListViewTable.module.css
+++ b/package/src/ListViewTable.module.css
@@ -75,6 +75,19 @@
   transition: box-shadow 200ms ease;
 }
 
+/* Mantine's sticky thead defaults to `z-index: 3` (or `4` with
+ * `withTableBorder`), while our sticky body cells use `z-index: 10`
+ * (see `.stickyColumn`). Without this override, body cells in a
+ * sticky-left/right column would render *above* the thead while the
+ * user scrolls vertically — visible as a duplicated first-row peek
+ * next to the pinned column. Match Mantine's selector specificity
+ * (`.classname[attr]`) so we win the cascade and bump the thead above
+ * the body sticky-column z-index. The rule only applies when the
+ * thead is in sticky mode, so it has no effect on non-sticky tables. */
+.header[data-sticky] {
+  z-index: 12;
+}
+
 .headerCell {
   /* No overflow:hidden here — it would clip the resize handle that extends beyond the th */
   padding: var(--list-view-vertical-spacing) var(--list-view-horizontal-spacing);

--- a/package/src/ListViewTable.module.css
+++ b/package/src/ListViewTable.module.css
@@ -249,23 +249,43 @@
  * `mantine-datatable`. No backdrop-filter, no transparency: the only edge
  * cue is the gradient shadow span (see `.stickyColumnShadow` below).
  */
+/*
+ * `position: sticky`, `left`, and `right` are set inline by the renderer so
+ * each cell can pick the correct side for its `column.sticky` value. The
+ * class only carries the cosmetic concerns (background + z-index) that
+ * apply equally to left- and right-pinned cells.
+ */
 .stickyColumn {
-  position: sticky;
-  left: 0;
   z-index: 10;
   background: var(--mantine-color-body);
 }
 
 .stickyHeaderColumn {
-  position: sticky;
-  left: 0;
   z-index: 11; /* Higher than body sticky columns */
   background: var(--mantine-color-body);
 }
 
-[data-mantine-color-scheme='dark'] .stickyColumn,
-[data-mantine-color-scheme='dark'] .stickyHeaderColumn {
-  background: var(--mantine-color-dark-7);
+/*
+ * Background "extension" on the inner edge of the last sticky-left and
+ * first sticky-right cell.
+ *
+ * The gradient shadow span (`.stickyColumnShadow`) fades from opaque
+ * shadow-color to transparent on its outer edge. Without this extension
+ * the transparent portion would let the underlying scroll content peek
+ * through — visible as fragments of letters drifting across the edge as
+ * the user scrolls. Adding a sharp `box-shadow` of the cell's own
+ * background color creates a 4px-wide opaque strip outside the cell that
+ * occludes whatever scrolls underneath, so the gradient fades into the
+ * cell's color rather than into bleeding-through content.
+ */
+.stickyColumn[data-sticky-shadow='left'],
+.stickyHeaderColumn[data-sticky-shadow='left'] {
+  box-shadow: var(--lvt-shadow-width, 4px) 0 0 0 var(--mantine-color-body);
+}
+
+.stickyColumn[data-sticky-shadow='right'],
+.stickyHeaderColumn[data-sticky-shadow='right'] {
+  box-shadow: calc(-1 * var(--lvt-shadow-width, 4px)) 0 0 0 var(--mantine-color-body);
 }
 
 /*

--- a/package/src/ListViewTable.module.css
+++ b/package/src/ListViewTable.module.css
@@ -268,9 +268,21 @@
   overflow: visible;
 }
 
+/*
+ * Dark-mode override.
+ *
+ * `background` is repeated explicitly here because the existing
+ * `[data-mantine-color-scheme='dark'] .headerCell { background: transparent }`
+ * rule has the same specificity (0,1,1) and would otherwise win the cascade
+ * for the header sticky cell — leaving it visually transparent and
+ * letting the underlying scrolled column bleed through. With `background`
+ * declared in this rule too the cascade picks the later declaration (this
+ * one), so the sticky cell stays opaque.
+ */
 [data-mantine-color-scheme='dark'] .stickyColumn,
 [data-mantine-color-scheme='dark'] .stickyHeaderColumn {
   --lvt-sticky-bg: var(--mantine-color-dark-7);
+  background: var(--lvt-sticky-bg);
 }
 
 /*

--- a/package/src/ListViewTable.module.css
+++ b/package/src/ListViewTable.module.css
@@ -54,10 +54,15 @@
   width: 100%;
 }
 
-/* Header base: let Mantine handle sticky positioning and borders via props */
+/* Header base: let Mantine handle sticky positioning and borders via props.
+ * The `box-shadow` fades in via `--lvt-header-shadow-opacity` (driven by
+ * `useStickyHeaderShadow`) once the thead becomes stuck. The same
+ * pattern as the sticky-column shadow: zero CSS rules to enable, no
+ * React re-renders during scroll. */
 .header {
   background: var(--mantine-color-white);
-  box-shadow: none;
+  box-shadow: 0 rem(4) rem(6) rem(-2) rgb(0 0 0 / calc(0.15 * var(--lvt-header-shadow-opacity, 0)));
+  transition: box-shadow 200ms ease;
 }
 
 .headerCell {
@@ -226,7 +231,7 @@
 [data-mantine-color-scheme='dark'] .header {
   background: var(--mantine-color-dark-7);
   border: none;
-  box-shadow: none;
+  box-shadow: 0 rem(4) rem(6) rem(-2) rgb(0 0 0 / calc(0.4 * var(--lvt-header-shadow-opacity, 0)));
 }
 
 [data-mantine-color-scheme='dark'] .headerCell {

--- a/package/src/ListViewTable.test.tsx
+++ b/package/src/ListViewTable.test.tsx
@@ -464,24 +464,25 @@ describe('ListViewTable', () => {
       expect(header?.getAttribute('data-sticky-side')).toBe('left');
     });
 
-    it('renders the shadow span only on the last sticky-left and first sticky-right columns', () => {
+    it('marks the last sticky-left and first sticky-right cells with data-sticky-shadow', () => {
       const { container } = render(
         <ListViewTable columns={pinnedColumns as any} data={pinnedData} rowKey="id" />
       );
-      // Only one shadow per side per row (header + body × 2 rows = 3 of each side)
-      const leftShadows = container.querySelectorAll('[data-side="left"]');
-      const rightShadows = container.querySelectorAll('[data-side="right"]');
-      // 1 header + 2 body rows = 3 each
-      expect(leftShadows.length).toBe(3);
-      expect(rightShadows.length).toBe(3);
+      // The shadow is rendered as a `::after` pseudo-element on every cell
+      // carrying `data-sticky-shadow`. With one header row + two body rows,
+      // we expect three cells per side to be marked.
+      const leftShadowCells = container.querySelectorAll('[data-sticky-shadow="left"]');
+      const rightShadowCells = container.querySelectorAll('[data-sticky-shadow="right"]');
+      expect(leftShadowCells.length).toBe(3);
+      expect(rightShadowCells.length).toBe(3);
     });
 
-    it('does not render shadows when no column is sticky', () => {
+    it('does not mark any cell with data-sticky-shadow when no column is sticky', () => {
       const { container } = render(
         <ListViewTable columns={testColumns as any} data={testData} rowKey="id" />
       );
-      expect(container.querySelectorAll('[data-side="left"]').length).toBe(0);
-      expect(container.querySelectorAll('[data-side="right"]').length).toBe(0);
+      expect(container.querySelectorAll('[data-sticky-shadow="left"]').length).toBe(0);
+      expect(container.querySelectorAll('[data-sticky-shadow="right"]').length).toBe(0);
     });
   });
 });

--- a/package/src/ListViewTable.test.tsx
+++ b/package/src/ListViewTable.test.tsx
@@ -422,4 +422,66 @@ describe('ListViewTable', () => {
     );
     expect(container.querySelector('table')).toBeTruthy();
   });
+
+  describe('pinned columns', () => {
+    const pinnedColumns = [
+      { key: 'name', title: 'Name', sticky: 'left' as const },
+      { key: 'value', title: 'Value' },
+      { key: 'tags', title: 'Tags' },
+      { key: 'actions', title: 'Actions', sticky: 'right' as const },
+    ];
+
+    const pinnedData = [
+      { id: 1, name: 'A', value: 'v1', tags: 't1', actions: 'open' },
+      { id: 2, name: 'B', value: 'v2', tags: 't2', actions: 'open' },
+    ];
+
+    it('attaches data-sticky-side="left" to columns with sticky="left"', () => {
+      const { container } = render(
+        <ListViewTable columns={pinnedColumns as any} data={pinnedData} rowKey="id" />
+      );
+      const leftHeader = container.querySelector('th[data-column-key="name"]');
+      expect(leftHeader?.getAttribute('data-sticky-side')).toBe('left');
+    });
+
+    it('attaches data-sticky-side="right" to columns with sticky="right"', () => {
+      const { container } = render(
+        <ListViewTable columns={pinnedColumns as any} data={pinnedData} rowKey="id" />
+      );
+      const rightHeader = container.querySelector('th[data-column-key="actions"]');
+      expect(rightHeader?.getAttribute('data-sticky-side')).toBe('right');
+    });
+
+    it('treats sticky=true as sticky="left" for backward compatibility', () => {
+      const cols = [
+        { key: 'name', title: 'Name', sticky: true },
+        { key: 'value', title: 'Value' },
+      ];
+      const { container } = render(
+        <ListViewTable columns={cols as any} data={pinnedData} rowKey="id" />
+      );
+      const header = container.querySelector('th[data-column-key="name"]');
+      expect(header?.getAttribute('data-sticky-side')).toBe('left');
+    });
+
+    it('renders the shadow span only on the last sticky-left and first sticky-right columns', () => {
+      const { container } = render(
+        <ListViewTable columns={pinnedColumns as any} data={pinnedData} rowKey="id" />
+      );
+      // Only one shadow per side per row (header + body × 2 rows = 3 of each side)
+      const leftShadows = container.querySelectorAll('[data-side="left"]');
+      const rightShadows = container.querySelectorAll('[data-side="right"]');
+      // 1 header + 2 body rows = 3 each
+      expect(leftShadows.length).toBe(3);
+      expect(rightShadows.length).toBe(3);
+    });
+
+    it('does not render shadows when no column is sticky', () => {
+      const { container } = render(
+        <ListViewTable columns={testColumns as any} data={testData} rowKey="id" />
+      );
+      expect(container.querySelectorAll('[data-side="left"]').length).toBe(0);
+      expect(container.querySelectorAll('[data-side="right"]').length).toBe(0);
+    });
+  });
 });

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -12,6 +12,8 @@ import {
   createVarsResolver,
   factory,
   Factory,
+  getRadius,
+  getThemeColor,
   Group,
   Loader,
   MantineColor,
@@ -84,12 +86,12 @@ export interface ListViewTableBaseProps<T = any> {
   layout?: React.CSSProperties['tableLayout'];
 
   /**
-   * Whether to show table borders. When `scrollProps` is set the border is
-   * rendered on the outer (non-scrolling) container so it stays fixed during
-   * horizontal scroll, even with sticky columns. When `scrollProps` is not
-   * set the border falls back to Mantine's native `<table>` border (which
-   * scrolls with the content if the table is wrapped in
-   * `Table.ScrollContainer`).
+   * Whether to draw the table border. When set, the border is always
+   * rendered on the outer (non-scrolling) `.root` container — never on
+   * the inner `<table>` — so it stays fixed during horizontal/vertical
+   * scroll even with sticky columns. Use `borderRadius` and
+   * `borderWidth` to customize its shape, and `borderColor` to recolor
+   * it.
    */
   withTableBorder?: boolean;
 
@@ -410,32 +412,39 @@ const defaultProps: Partial<ListViewTableProps> = {
 // Most CSS variables are set to undefined here because they are managed by
 // ListViewTableMediaVariables via InlineStyles + CSS media queries to support
 // responsive breakpoint values. Only non-responsive variables are resolved here.
-const varsResolver = createVarsResolver<ListViewTableFactory>((_, { selectedRowColor }) => ({
-  root: {
-    '--list-view-height': undefined,
-    '--list-view-width': undefined,
-    '--list-view-horizontal-spacing': undefined,
-    '--list-view-vertical-spacing': undefined,
-    '--list-view-header-title-font-size': undefined,
-    '--list-view-header-title-font-weight': undefined,
-    '--list-view-cell-font-size': undefined,
-    '--list-view-cell-font-weight': undefined,
-    '--list-view-selected-row-color': selectedRowColor || undefined,
-    // Sticky-column shadow vars — `*-opacity` are written by
-    // `useStickyShadow` on every horizontal scroll. `*-color` and
-    // `*-width` use CSS fallbacks (declared via `var(name, fallback)` in
-    // the stylesheet) so consumers can override them through `vars` or
-    // external CSS without us hard-coding a value here.
-    '--lvt-shadow-color': undefined,
-    '--lvt-shadow-width': undefined,
-    '--lvt-shadow-left-opacity': undefined,
-    '--lvt-shadow-right-opacity': undefined,
-    // Sticky-header shadow opacity is written by `useStickyHeaderShadow`
-    // on vertical scroll. To customize the shadow shape/color, override
-    // `.mantine-ListViewTable-header` via the Styles API.
-    '--lvt-header-shadow-opacity': undefined,
-  },
-}));
+const varsResolver = createVarsResolver<ListViewTableFactory>(
+  (theme, { selectedRowColor, borderColor }) => ({
+    root: {
+      '--list-view-height': undefined,
+      '--list-view-width': undefined,
+      '--list-view-horizontal-spacing': undefined,
+      '--list-view-vertical-spacing': undefined,
+      '--list-view-header-title-font-size': undefined,
+      '--list-view-header-title-font-weight': undefined,
+      '--list-view-cell-font-size': undefined,
+      '--list-view-cell-font-weight': undefined,
+      '--list-view-selected-row-color': selectedRowColor || undefined,
+      // Resolved value of the `borderColor` prop. Used by the wrapper
+      // border (since `withTableBorder` is always rendered on `.root`,
+      // not on Mantine's native `<table>`). Falls back in the CSS to
+      // the default border color when not provided.
+      '--lvt-border-color': borderColor ? getThemeColor(borderColor, theme) : undefined,
+      // Sticky-column shadow vars — `*-opacity` are written by
+      // `useStickyShadow` on every horizontal scroll. `*-color` and
+      // `*-width` use CSS fallbacks (declared via `var(name, fallback)` in
+      // the stylesheet) so consumers can override them through `vars` or
+      // external CSS without us hard-coding a value here.
+      '--lvt-shadow-color': undefined,
+      '--lvt-shadow-width': undefined,
+      '--lvt-shadow-left-opacity': undefined,
+      '--lvt-shadow-right-opacity': undefined,
+      // Sticky-header shadow opacity is written by `useStickyHeaderShadow`
+      // on vertical scroll. To customize the shadow shape/color, override
+      // `.mantine-ListViewTable-header` via the Styles API.
+      '--lvt-header-shadow-opacity': undefined,
+    },
+  })
+);
 
 export const ListViewTable = factory<ListViewTableFactory>((_props) => {
   const props = useProps('ListViewTable', defaultProps, _props);
@@ -1111,7 +1120,7 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
         className: responsiveClassName,
         style: withTableBorder
           ? {
-              borderRadius: `var(--mantine-radius-${borderRadius || 'sm'})`,
+              borderRadius: getRadius(borderRadius ?? 'sm'),
               ...(borderWidth !== undefined
                 ? {
                     borderWidth: typeof borderWidth === 'number' ? `${borderWidth}px` : borderWidth,
@@ -1149,7 +1158,7 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
             ...(scrollEnabled ? { overflow: 'auto', maxHeight: scrollProps?.maxHeight } : null),
             ...(withTableBorder
               ? {
-                  clipPath: `inset(0 round var(--mantine-radius-${borderRadius || 'sm'}))`,
+                  clipPath: `inset(0 round ${getRadius(borderRadius ?? 'sm')})`,
                 }
               : null),
           }

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -36,6 +36,7 @@ import { useKeyboardNavigation } from './hooks/use-keyboard-navigation';
 import { useLongPress } from './hooks/use-long-press';
 import { useRowSelection } from './hooks/use-row-selection';
 import { useSorting } from './hooks/use-sorting';
+import { useStickyHeaderShadow } from './hooks/use-sticky-header-shadow';
 import { useStickyShadow } from './hooks/use-sticky-shadow';
 import { ListViewTableMediaVariables } from './ListViewTableMediaVariables';
 import { ResizeHandle } from './ResizeHandle';
@@ -93,12 +94,19 @@ export interface ListViewTableBaseProps<T = any> {
   withTableBorder?: boolean;
 
   /**
-   * Border radius of the outer container when `scrollProps` is set. Mirrors
-   * Mantine's radius scale; ignored when `scrollProps` is not provided.
+   * Border radius of the outer container when `withTableBorder` is set.
+   * Mirrors Mantine's radius scale.
    *
    * @default 'sm'
    */
   borderRadius?: MantineRadius;
+
+  /**
+   * Width of the outer border when `withTableBorder` is set. Accepts any
+   * CSS length (numbers are treated as `px`). When omitted, the default
+   * thickness from the stylesheet is used.
+   */
+  borderWidth?: number | string;
 
   /**
    * When provided, ListViewTable renders its own scroll wrapper around the
@@ -443,6 +451,7 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
     captionSide,
     borderColor,
     borderRadius,
+    borderWidth,
     withTableBorder,
     scrollProps,
     withColumnBorders,
@@ -615,6 +624,14 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
   // table element so the CSS pseudo-elements on pinned columns can fade in
   // when there is content scrolled beyond either edge.
   useStickyShadow({ tableRef, enabled: hasStickyColumns });
+
+  // Drives `--lvt-header-shadow-opacity` so the CSS layer can fade a
+  // soft drop-shadow under the thead when it becomes stuck.
+  useStickyHeaderShadow({
+    tableRef,
+    enabled: !!stickyHeader,
+    offset: stickyHeaderOffset,
+  });
 
   const {
     handleRowClick: handleSelectionClick,
@@ -1089,7 +1106,14 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
       {...getStyles('root', {
         className: responsiveClassName,
         style: withTableBorder
-          ? { borderRadius: `var(--mantine-radius-${borderRadius || 'sm'})` }
+          ? {
+              borderRadius: `var(--mantine-radius-${borderRadius || 'sm'})`,
+              ...(borderWidth !== undefined
+                ? {
+                    borderWidth: typeof borderWidth === 'number' ? `${borderWidth}px` : borderWidth,
+                  }
+                : null),
+            }
           : undefined,
       })}
       tabIndex={kbEnabled ? 0 : undefined}

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -35,6 +35,7 @@ import { useKeyboardNavigation } from './hooks/use-keyboard-navigation';
 import { useLongPress } from './hooks/use-long-press';
 import { useRowSelection } from './hooks/use-row-selection';
 import { useSorting } from './hooks/use-sorting';
+import { useStickyShadow } from './hooks/use-sticky-shadow';
 import { ListViewTableMediaVariables } from './ListViewTableMediaVariables';
 import { ResizeHandle } from './ResizeHandle';
 import type {
@@ -372,6 +373,15 @@ const varsResolver = createVarsResolver<ListViewTableFactory>((_, { selectedRowC
     '--list-view-cell-font-weight': undefined,
     '--list-view-selected-row-color': selectedRowColor || undefined,
     '--list-view-sticky-blur': undefined,
+    // Sticky-column shadow vars — `*-opacity` are written by `useStickyShadow`
+    // on every horizontal scroll. `*-color` and `*-width` use CSS fallbacks
+    // (declared via `var(name, fallback)` in the stylesheet) so consumers can
+    // override them through `vars` or external CSS without us hard-coding a
+    // value here.
+    '--lvt-shadow-color': undefined,
+    '--lvt-shadow-width': undefined,
+    '--lvt-shadow-left-opacity': undefined,
+    '--lvt-shadow-right-opacity': undefined,
   },
 }));
 
@@ -531,6 +541,39 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
     onColumnResize,
   });
 
+  // Pre-compute pinning side per visible column and find the columns that
+  // own the gradient shadow (last sticky-left, first sticky-right).
+  // `sticky === true` is normalized to `'left'` for backward compatibility.
+  const stickyInfo = useMemo(() => {
+    const sides: (null | 'left' | 'right')[] = visibleColumns.map((col) => {
+      if (col.sticky === true || col.sticky === 'left') {
+        return 'left';
+      }
+      if (col.sticky === 'right') {
+        return 'right';
+      }
+      return null;
+    });
+    let lastLeftIdx = -1;
+    let firstRightIdx = -1;
+    sides.forEach((side, i) => {
+      if (side === 'left') {
+        lastLeftIdx = i;
+      }
+      if (side === 'right' && firstRightIdx === -1) {
+        firstRightIdx = i;
+      }
+    });
+    return { sides, lastLeftIdx, firstRightIdx };
+  }, [visibleColumns]);
+
+  const hasStickyColumns = stickyInfo.lastLeftIdx !== -1 || stickyInfo.firstRightIdx !== -1;
+
+  // Drives `--lvt-shadow-left-opacity` / `--lvt-shadow-right-opacity` on the
+  // table element so the CSS pseudo-elements on pinned columns can fade in
+  // when there is content scrolled beyond either edge.
+  useStickyShadow({ tableRef, enabled: hasStickyColumns });
+
   const {
     handleRowClick: handleSelectionClick,
     isSelected,
@@ -647,15 +690,39 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
       const title = column.title || humanize(column.key as string);
       const columnStyle = getColumnStyle(column, index);
 
+      const stickySide = stickyInfo.sides[index];
+      const shadowSide =
+        index === stickyInfo.lastLeftIdx
+          ? 'left'
+          : index === stickyInfo.firstRightIdx
+            ? 'right'
+            : undefined;
+
+      const stickyPositionStyle =
+        stickySide === 'left'
+          ? {
+              position: 'sticky' as const,
+              left: 0,
+              zIndex: 11,
+              // Allow the shadow ::after to extend outside the cell border.
+              overflow: 'visible' as const,
+            }
+          : stickySide === 'right'
+            ? {
+                position: 'sticky' as const,
+                right: 0,
+                zIndex: 11,
+                overflow: 'visible' as const,
+              }
+            : { position: 'relative' as const };
+
       return (
         <Table.Th
           key={column.key as React.Key}
           {...getStyles('headerCell', {
-            className: column.sticky ? getStyles('stickyHeaderColumn').className : undefined,
+            className: stickySide ? getStyles('stickyHeaderColumn').className : undefined,
             style: {
-              ...(column.sticky
-                ? { position: 'sticky', left: 0, zIndex: 11 }
-                : { position: 'relative' }),
+              ...stickyPositionStyle,
               ...columnStyle,
               textAlign: column.textAlign,
               top: 0,
@@ -665,6 +732,8 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
           data-drag-over={dragOverColumn === index ? 'true' : undefined}
           data-focused={focusedColumn === index ? 'true' : undefined}
           data-column-key={column.key as string}
+          data-sticky-side={stickySide ?? undefined}
+          data-sticky-shadow={shadowSide}
         >
           <Group
             gap={0}
@@ -747,6 +816,13 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
                 getStyles={() => getStyles('resizeHandle')}
               />
             )}
+
+          {/* Pinned-column edge shadow — only on the last sticky-left and the
+              first sticky-right column. CSS variables on the table root drive
+              the opacity transition in response to scroll. */}
+          {shadowSide && (
+            <span {...getStyles('stickyColumnShadow')} data-side={shadowSide} aria-hidden />
+          )}
         </Table.Th>
       );
     },
@@ -766,6 +842,7 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
       getColumnStyle,
       getStyles,
       headerLongPress.didLongPressRef,
+      stickyInfo,
     ]
   );
 
@@ -781,13 +858,52 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
           ? column.cellClassName(record, rowIndex)
           : column.cellClassName;
 
-      const stickyColumnClass = column.sticky ? getStyles('stickyColumn').className : '';
+      const stickySide = stickyInfo.sides[colIdx];
+      const shadowSide =
+        colIdx === stickyInfo.lastLeftIdx
+          ? 'left'
+          : colIdx === stickyInfo.firstRightIdx
+            ? 'right'
+            : undefined;
+
+      const stickyColumnClass = stickySide ? getStyles('stickyColumn').className : '';
       const finalCellClassName = [cellClassName, stickyColumnClass].filter(Boolean).join(' ');
 
       const cellStyle =
         typeof column.cellStyle === 'function'
           ? column.cellStyle(record, rowIndex)
           : column.cellStyle;
+
+      // For sticky cells, the Td must keep `overflow: visible` so the shadow
+      // pseudo-element can render outside the cell border. Ellipsis rules
+      // therefore move to an inner wrapper. Non-sticky cells keep the
+      // existing simpler structure (ellipsis directly on the Td).
+      const ellipsisStyle = column.ellipsis
+        ? {
+            whiteSpace: 'nowrap' as const,
+            textOverflow: 'ellipsis' as const,
+            overflow: 'hidden' as const,
+          }
+        : column.noWrap || noWrap
+          ? { whiteSpace: 'nowrap' as const }
+          : undefined;
+
+      const cellInner = stickySide ? <div style={ellipsisStyle}>{cellContent}</div> : cellContent;
+
+      const shadowEl = shadowSide ? (
+        <span {...getStyles('stickyColumnShadow')} data-side={shadowSide} aria-hidden />
+      ) : null;
+
+      const stickyPositionStyle =
+        stickySide === 'left'
+          ? { position: 'sticky' as const, left: 0, zIndex: 10, overflow: 'visible' as const }
+          : stickySide === 'right'
+            ? { position: 'sticky' as const, right: 0, zIndex: 10, overflow: 'visible' as const }
+            : {
+                whiteSpace: column.noWrap || noWrap ? ('nowrap' as const) : undefined,
+                textOverflow: column.ellipsis ? ('ellipsis' as const) : undefined,
+                overflow: 'hidden' as const,
+              };
 
       return (
         <Table.Td
@@ -797,23 +913,21 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
             style: {
               ...columnStyle,
               textAlign: column.textAlign,
-              whiteSpace: column.noWrap || noWrap ? 'nowrap' : undefined,
-              textOverflow: column.ellipsis ? 'ellipsis' : undefined,
-              overflow: 'hidden',
-              position: column.sticky ? 'sticky' : undefined,
-              left: column.sticky ? 0 : undefined,
-              zIndex: column.sticky ? 10 : undefined,
+              ...stickyPositionStyle,
               verticalAlign,
               ...cellStyle,
             },
           })}
           data-column-key={column.key as string}
+          data-sticky-side={stickySide ?? undefined}
+          data-sticky-shadow={shadowSide}
         >
-          {cellContent}
+          {cellInner}
+          {shadowEl}
         </Table.Td>
       );
     },
-    [noWrap, verticalAlign, getStyles, getColumnStyle]
+    [noWrap, verticalAlign, getStyles, getColumnStyle, stickyInfo]
   );
 
   const isVertical = tableProps?.variant === 'vertical';

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -1200,13 +1200,17 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
           {...tableProps}
           ref={tableRef}
         >
-          {/* `<colgroup>` is the canonical way to lock per-column
-              widths in `table-layout: fixed`. Cell-level inline
-              `width` is ignored by Chromium when any cell is
-              `position: sticky`, but `<col>` widths are always
-              honored. We render it only while resize is active so the
-              non-resize render is unaffected. */}
-          {isResizeActive && (
+          {/* `<colgroup>` is rendered only when both resize is active
+              AND a pinned column exists. Cell-level inline `width` on
+              a `position: sticky` `<th>` is ignored by Chromium under
+              `table-layout: fixed`, but `<col>` widths are always
+              honored — so we use the colgroup as the override layer
+              specifically for pinned tables. Non-sticky resize keeps
+              the original `<th>` width path unchanged so its layout
+              behavior (table width clamped by `min-width: 100%`,
+              standard/finder mode column distribution) is identical
+              to what it was before this fix landed. */}
+          {isResizeActive && hasStickyColumns && (
             <colgroup>
               {visibleColumns.map((column) => {
                 const w = columnWidths[column.key as string];

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -1089,17 +1089,7 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
       {...getStyles('root', {
         className: responsiveClassName,
         style: withTableBorder
-          ? {
-              borderRadius: `var(--mantine-radius-${borderRadius || 'sm'})`,
-              // `clip-path` clips the rounded corners without making
-              // `.root` a scroll containing block — using `overflow:
-              // hidden` here would break `position: sticky` on the
-              // table header (it would pin to `.root` instead of the
-              // page viewport). The `padding-box` reference keeps the
-              // clip strictly inside the wrapper's border so the border
-              // line is rendered intact at the corners.
-              clipPath: `inset(0 round var(--mantine-radius-${borderRadius || 'sm'})) padding-box`,
-            }
+          ? { borderRadius: `var(--mantine-radius-${borderRadius || 'sm'})` }
           : undefined,
       })}
       tabIndex={kbEnabled ? 0 : undefined}
@@ -1114,14 +1104,27 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
       <div
         {...getStyles('scrollViewport')}
         style={
-          scrollEnabled
-            ? { overflow: 'auto', maxHeight: scrollProps?.maxHeight }
-            : /* `display: contents` makes the wrapper invisible to layout
-                 so the `<Table>` behaves exactly as if it were a direct
-                 child of the outer `<Box>`, preserving the original
-                 (no-internal-scroll) rendering when `scrollProps` is not
-                 set. */
-              { display: 'contents' }
+          /* The wrapper carries `clip-path` (when `withTableBorder` is
+             set) so the table content is clipped to the rounded shape
+             of `.root`. The border lives on `.root` and is left
+             untouched by this clip, so the corners stay crisp.
+             `clip-path` does NOT establish a scroll containing block,
+             which keeps `position: sticky` on the table header working
+             correctly relative to the page viewport.
+
+             In `scrollEnabled` mode this same `<div>` becomes the
+             native scroll viewport; the `clip-path` continues to
+             clip the rounded corners during horizontal/vertical
+             scroll so the wrapper's rounded border always frames the
+             scrolled content. */
+          {
+            ...(scrollEnabled ? { overflow: 'auto', maxHeight: scrollProps?.maxHeight } : null),
+            ...(withTableBorder
+              ? {
+                  clipPath: `inset(0 round var(--mantine-radius-${borderRadius || 'sm'}))`,
+                }
+              : null),
+          }
         }
       >
         <Table

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -593,7 +593,6 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
   });
 
   const {
-    columnWidths,
     isResizeActive,
     getColumnStyle,
     getTableStyle,
@@ -680,14 +679,7 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
     onSelectAll: selectionMode === 'multiple' ? selectAll : undefined,
   });
 
-  // Dynamic table-layout (resolves Issue #4).
-  //
-  // While resize is active we use `fixed` so the explicit pixel widths
-  // the hook writes are honored exactly with no proportional
-  // auto-distribution and no content-driven track expansion. Track
-  // widths are sourced from a `<colgroup>` we render below — this
-  // works even with `position: sticky` cells (where Chromium would
-  // ignore inline `<th>`/`<td>` widths under fixed layout).
+  // Dynamic table-layout (resolves Issue #4)
   const tableLayout = useMemo(() => {
     if (layout) {
       return layout;
@@ -1200,29 +1192,6 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
           {...tableProps}
           ref={tableRef}
         >
-          {/* `<colgroup>` is rendered only when both resize is active
-              AND a pinned column exists. Cell-level inline `width` on
-              a `position: sticky` `<th>` is ignored by Chromium under
-              `table-layout: fixed`, but `<col>` widths are always
-              honored — so we use the colgroup as the override layer
-              specifically for pinned tables. Non-sticky resize keeps
-              the original `<th>` width path unchanged so its layout
-              behavior (table width clamped by `min-width: 100%`,
-              standard/finder mode column distribution) is identical
-              to what it was before this fix landed. */}
-          {isResizeActive && hasStickyColumns && (
-            <colgroup>
-              {visibleColumns.map((column) => {
-                const w = columnWidths[column.key as string];
-                return (
-                  <col
-                    key={column.key as React.Key}
-                    style={w ? { width: `${w}px` } : undefined}
-                  />
-                );
-              })}
-            </colgroup>
-          )}
           <Table.Thead
             {...getStyles('header')}
             onContextMenu={enableColumnVisibilityToggle ? handleHeaderContextMenu : undefined}

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -1171,7 +1171,18 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
       >
         <Table
           {...getStyles('table', {
-            style: { ...getTableStyle(), minWidth: scrollProps?.minWidth },
+            style: {
+              ...getTableStyle(),
+              // Only override `min-width` when `scrollProps.minWidth` is
+              // actually set, otherwise an `undefined` value would clobber
+              // the `min-width` that `getTableStyle()` already set for
+              // Finder/Standard resize and let the CSS-class
+              // `min-width: 100%` take over (which forces the table back
+              // to the parent width and redistributes columns evenly).
+              ...(scrollProps?.minWidth !== undefined
+                ? { minWidth: scrollProps.minWidth }
+                : null),
+            },
           })}
           /* Border lives on the outer `<Box>` wrapper (see CSS rule on
              `.root[data-with-table-border='true']`) so it stays fixed

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -593,6 +593,7 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
   });
 
   const {
+    columnWidths,
     isResizeActive,
     getColumnStyle,
     getTableStyle,
@@ -679,21 +680,20 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
     onSelectAll: selectionMode === 'multiple' ? selectAll : undefined,
   });
 
-  // Dynamic table-layout (resolves Issue #4)
-  // While resize is active we explicitly use `auto` even though the
-  // intuition is "lock to fixed for stability". Reason: under
-  // `table-layout: fixed` Chromium re-distributes track widths evenly
-  // when any cell is `position: sticky` (the whole pinned-column case)
-  // and the explicit `width` / `min-width` / `max-width` set inline by
-  // `useColumnResize` is silently ignored. With `auto` the inline cell
-  // widths are honored, and stability is preserved by the locked table
-  // width returned from `getTableStyle()`.
+  // Dynamic table-layout (resolves Issue #4).
+  //
+  // While resize is active we use `fixed` so the explicit pixel widths
+  // the hook writes are honored exactly with no proportional
+  // auto-distribution and no content-driven track expansion. Track
+  // widths are sourced from a `<colgroup>` we render below — this
+  // works even with `position: sticky` cells (where Chromium would
+  // ignore inline `<th>`/`<td>` widths under fixed layout).
   const tableLayout = useMemo(() => {
     if (layout) {
       return layout;
     }
     if (isResizeActive) {
-      return 'auto' as const;
+      return 'fixed' as const;
     }
     return undefined;
   }, [layout, isResizeActive]);
@@ -1200,6 +1200,25 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
           {...tableProps}
           ref={tableRef}
         >
+          {/* `<colgroup>` is the canonical way to lock per-column
+              widths in `table-layout: fixed`. Cell-level inline
+              `width` is ignored by Chromium when any cell is
+              `position: sticky`, but `<col>` widths are always
+              honored. We render it only while resize is active so the
+              non-resize render is unaffected. */}
+          {isResizeActive && (
+            <colgroup>
+              {visibleColumns.map((column) => {
+                const w = columnWidths[column.key as string];
+                return (
+                  <col
+                    key={column.key as React.Key}
+                    style={w ? { width: `${w}px` } : undefined}
+                  />
+                );
+              })}
+            </colgroup>
+          )}
           <Table.Thead
             {...getStyles('header')}
             onContextMenu={enableColumnVisibilityToggle ? handleHeaderContextMenu : undefined}

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -15,6 +15,7 @@ import {
   Group,
   Loader,
   MantineColor,
+  MantineRadius,
   MantineSpacing,
   Menu,
   Stack,
@@ -82,9 +83,48 @@ export interface ListViewTableBaseProps<T = any> {
   layout?: React.CSSProperties['tableLayout'];
 
   /**
-   * Whether to show table borders.
+   * Whether to show table borders. When `scrollProps` is set the border is
+   * rendered on the outer (non-scrolling) container so it stays fixed during
+   * horizontal scroll, even with sticky columns. When `scrollProps` is not
+   * set the border falls back to Mantine's native `<table>` border (which
+   * scrolls with the content if the table is wrapped in
+   * `Table.ScrollContainer`).
    */
   withTableBorder?: boolean;
+
+  /**
+   * Border radius of the outer container when `scrollProps` is set. Mirrors
+   * Mantine's radius scale; ignored when `scrollProps` is not provided.
+   *
+   * @default 'sm'
+   */
+  borderRadius?: MantineRadius;
+
+  /**
+   * When provided, ListViewTable renders its own scroll wrapper around the
+   * `<Table>` instead of relying on `Mantine.Table.ScrollContainer`. The
+   * outer container is non-scrolling, which lets the table border and
+   * border-radius stay fixed while only the inner viewport scrolls — the
+   * recommended setup for sticky columns combined with `withTableBorder`.
+   *
+   * Pass `minWidth` to force horizontal scroll when the table content is
+   * wider than its container, and `maxHeight` to enable vertical scroll.
+   *
+   * @example
+   * ```tsx
+   * <ListViewTable
+   *   columns={columns}
+   *   data={data}
+   *   withTableBorder
+   *   borderRadius="md"
+   *   scrollProps={{ minWidth: 1300 }}
+   * />
+   * ```
+   */
+  scrollProps?: {
+    minWidth?: number | string;
+    maxHeight?: number | string;
+  };
 
   /**
    * Whether to show column borders.
@@ -344,6 +384,7 @@ const defaultProps: Partial<ListViewTableProps> = {
   width: '100%',
   emptyText: 'No data available',
   withTableBorder: false,
+  borderRadius: 'sm',
   withRowBorders: true,
   withColumnBorders: true,
   highlightOnHover: false,
@@ -401,7 +442,9 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
     layout,
     captionSide,
     borderColor,
+    borderRadius,
     withTableBorder,
+    scrollProps,
     withColumnBorders,
     withRowBorders,
     striped,
@@ -1031,128 +1074,162 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
   }
 
   // === Render: Normal table ===
+  // When `scrollProps` is set, ListViewTable owns the scroll context: an
+  // outer non-scrolling `<Box>` holds the border + border-radius, and an
+  // inner viewport `<div>` does native horizontal/vertical scrolling. This
+  // is the recommended setup for sticky columns + `withTableBorder` because
+  // the border stays fixed regardless of scroll position. When `scrollProps`
+  // is not set we render the `<Table>` inline and let the consumer wrap us
+  // in `Mantine.Table.ScrollContainer` (or any other scroller) — Mantine's
+  // native `<table>` border then carries the border, but it scrolls with
+  // the table content.
+  const scrollEnabled = !!scrollProps;
   return (
     <Box
-      {...getStyles('root', { className: responsiveClassName })}
+      {...getStyles('root', {
+        className: responsiveClassName,
+        style:
+          scrollEnabled && withTableBorder
+            ? { borderRadius: `var(--mantine-radius-${borderRadius || 'sm'})` }
+            : undefined,
+      })}
       tabIndex={kbEnabled ? 0 : undefined}
       onKeyDown={kbEnabled ? handleKeyDown : undefined}
       data-dragging={draggedColumn !== null ? 'true' : undefined}
       data-resizing={isResizeActive ? 'true' : undefined}
+      data-with-table-border={scrollEnabled && withTableBorder ? 'true' : undefined}
+      data-with-scroll={scrollEnabled ? 'true' : undefined}
       {...others}
     >
       {mediaVariables}
-      <Table
-        {...getStyles('table', { style: getTableStyle() })}
-        withTableBorder={withTableBorder}
-        withColumnBorders={withColumnBorders}
-        withRowBorders={withRowBorders}
-        striped={striped}
-        stripedColor={stripedColor}
-        highlightOnHover={highlightOnHover && !selectionMode}
-        highlightOnHoverColor={highlightOnHoverColor}
-        /* horizontalSpacing and verticalSpacing are intentionally NOT passed here.
+      <div
+        {...getStyles('scrollViewport')}
+        style={
+          scrollEnabled
+            ? { overflow: 'auto', maxHeight: scrollProps?.maxHeight }
+            : /* `display: contents` makes the wrapper invisible to layout
+                 so the `<Table>` behaves exactly as if it were a direct
+                 child of the outer `<Box>`, preserving the original
+                 (no-internal-scroll) rendering when `scrollProps` is not
+                 set. */
+              { display: 'contents' }
+        }
+      >
+        <Table
+          {...getStyles('table', {
+            style: { ...getTableStyle(), minWidth: scrollProps?.minWidth },
+          })}
+          withTableBorder={scrollEnabled ? false : withTableBorder}
+          withColumnBorders={withColumnBorders}
+          withRowBorders={withRowBorders}
+          striped={striped}
+          stripedColor={stripedColor}
+          highlightOnHover={highlightOnHover && !selectionMode}
+          highlightOnHoverColor={highlightOnHoverColor}
+          /* horizontalSpacing and verticalSpacing are intentionally NOT passed here.
            Cell padding is controlled via --list-view-horizontal-spacing / --list-view-vertical-spacing
            CSS variables set by ListViewTableMediaVariables, which supports responsive breakpoints. */
-        borderColor={borderColor}
-        captionSide={captionSide}
-        stickyHeader={stickyHeader}
-        stickyHeaderOffset={stickyHeaderOffset}
-        tabularNums={tabularNums}
-        layout={tableLayout}
-        {...tableProps}
-        ref={tableRef}
-      >
-        <Table.Thead
-          {...getStyles('header')}
-          onContextMenu={enableColumnVisibilityToggle ? handleHeaderContextMenu : undefined}
-          {...(enableColumnVisibilityToggle
-            ? {
-                onPointerDown: headerLongPress.onPointerDown,
-                onPointerMove: headerLongPress.onPointerMove,
-                onPointerUp: headerLongPress.onPointerUp,
-                onPointerCancel: headerLongPress.onPointerCancel,
-              }
-            : {})}
+          borderColor={borderColor}
+          captionSide={captionSide}
+          stickyHeader={stickyHeader}
+          stickyHeaderOffset={stickyHeaderOffset}
+          tabularNums={tabularNums}
+          layout={tableLayout}
+          {...tableProps}
+          ref={tableRef}
         >
-          <Table.Tr>
-            {visibleColumns.map((column, index) => renderHeaderCell(column, index))}
-          </Table.Tr>
-        </Table.Thead>
-
-        <Table.Tbody {...getStyles('body')}>
-          {sortedData.map((record, rowIndex) => {
-            const key = getRowKey(record, rowIndex);
-            const rowClassNameValue =
-              typeof rowClassName === 'function' ? rowClassName(record, rowIndex) : rowClassName;
-
-            let rowStyleValue: React.CSSProperties = {};
-            if (typeof rowStyle === 'function') {
-              rowStyleValue = rowStyle(record, rowIndex) || {};
-            } else if (rowStyle) {
-              rowStyleValue = rowStyle;
-            }
-
-            const selected = isSelected(key);
-            const focused = focusedRowIndex === rowIndex;
-
-            const combinedStyle: React.CSSProperties = {
-              cursor: onRowClick || onRowDoubleClick || selectionMode ? 'pointer' : 'default',
-              ...rowStyleValue,
-            };
-
-            const rowClasses = [
-              rowClassNameValue,
-              selected ? getStyles('selectedRow').className : undefined,
-              focused ? getStyles('focusedRow').className : undefined,
-            ]
-              .filter(Boolean)
-              .join(' ');
-
-            return (
-              <Table.Tr
-                key={key}
-                {...getStyles('row', { style: combinedStyle })}
-                className={rowClasses || undefined}
-                onClick={(event) => {
-                  // Suppress click after a long-press on touch
-                  if (rowLongPress.didLongPressRef.current) {
-                    rowLongPress.didLongPressRef.current = false;
-                    return;
-                  }
-                  if (selectionMode) {
-                    handleSelectionClick(rowIndex, event);
-                    setFocusedRowIndex(rowIndex);
-                  }
-                  onRowClick?.(record, rowIndex, event);
-                }}
-                onDoubleClick={(event) => onRowDoubleClick?.(record, rowIndex, event)}
-                onContextMenu={
-                  renderContextMenu || onRowContextMenu
-                    ? (event) => handleRowContextMenu(record, rowIndex, event)
-                    : undefined
+          <Table.Thead
+            {...getStyles('header')}
+            onContextMenu={enableColumnVisibilityToggle ? handleHeaderContextMenu : undefined}
+            {...(enableColumnVisibilityToggle
+              ? {
+                  onPointerDown: headerLongPress.onPointerDown,
+                  onPointerMove: headerLongPress.onPointerMove,
+                  onPointerUp: headerLongPress.onPointerUp,
+                  onPointerCancel: headerLongPress.onPointerCancel,
                 }
-                {...(renderContextMenu
-                  ? {
-                      onPointerDown: (e: React.PointerEvent) => {
-                        longPressRowRef.current = { record, index: rowIndex };
-                        rowLongPress.onPointerDown(e);
-                      },
-                      onPointerMove: rowLongPress.onPointerMove,
-                      onPointerUp: rowLongPress.onPointerUp,
-                      onPointerCancel: rowLongPress.onPointerCancel,
+              : {})}
+          >
+            <Table.Tr>
+              {visibleColumns.map((column, index) => renderHeaderCell(column, index))}
+            </Table.Tr>
+          </Table.Thead>
+
+          <Table.Tbody {...getStyles('body')}>
+            {sortedData.map((record, rowIndex) => {
+              const key = getRowKey(record, rowIndex);
+              const rowClassNameValue =
+                typeof rowClassName === 'function' ? rowClassName(record, rowIndex) : rowClassName;
+
+              let rowStyleValue: React.CSSProperties = {};
+              if (typeof rowStyle === 'function') {
+                rowStyleValue = rowStyle(record, rowIndex) || {};
+              } else if (rowStyle) {
+                rowStyleValue = rowStyle;
+              }
+
+              const selected = isSelected(key);
+              const focused = focusedRowIndex === rowIndex;
+
+              const combinedStyle: React.CSSProperties = {
+                cursor: onRowClick || onRowDoubleClick || selectionMode ? 'pointer' : 'default',
+                ...rowStyleValue,
+              };
+
+              const rowClasses = [
+                rowClassNameValue,
+                selected ? getStyles('selectedRow').className : undefined,
+                focused ? getStyles('focusedRow').className : undefined,
+              ]
+                .filter(Boolean)
+                .join(' ');
+
+              return (
+                <Table.Tr
+                  key={key}
+                  {...getStyles('row', { style: combinedStyle })}
+                  className={rowClasses || undefined}
+                  onClick={(event) => {
+                    // Suppress click after a long-press on touch
+                    if (rowLongPress.didLongPressRef.current) {
+                      rowLongPress.didLongPressRef.current = false;
+                      return;
                     }
-                  : {})}
-                data-selected={selected ? 'true' : undefined}
-                data-focused={focused ? 'true' : undefined}
-              >
-                {visibleColumns.map((column, colIdx) =>
-                  renderCell(record, column, rowIndex, colIdx)
-                )}
-              </Table.Tr>
-            );
-          })}
-        </Table.Tbody>
-      </Table>
+                    if (selectionMode) {
+                      handleSelectionClick(rowIndex, event);
+                      setFocusedRowIndex(rowIndex);
+                    }
+                    onRowClick?.(record, rowIndex, event);
+                  }}
+                  onDoubleClick={(event) => onRowDoubleClick?.(record, rowIndex, event)}
+                  onContextMenu={
+                    renderContextMenu || onRowContextMenu
+                      ? (event) => handleRowContextMenu(record, rowIndex, event)
+                      : undefined
+                  }
+                  {...(renderContextMenu
+                    ? {
+                        onPointerDown: (e: React.PointerEvent) => {
+                          longPressRowRef.current = { record, index: rowIndex };
+                          rowLongPress.onPointerDown(e);
+                        },
+                        onPointerMove: rowLongPress.onPointerMove,
+                        onPointerUp: rowLongPress.onPointerUp,
+                        onPointerCancel: rowLongPress.onPointerCancel,
+                      }
+                    : {})}
+                  data-selected={selected ? 'true' : undefined}
+                  data-focused={focused ? 'true' : undefined}
+                >
+                  {visibleColumns.map((column, colIdx) =>
+                    renderCell(record, column, rowIndex, colIdx)
+                  )}
+                </Table.Tr>
+              );
+            })}
+          </Table.Tbody>
+        </Table>
+      </div>
 
       {/* Context Menu */}
       <Menu

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -1089,7 +1089,15 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
       {...getStyles('root', {
         className: responsiveClassName,
         style: withTableBorder
-          ? { borderRadius: `var(--mantine-radius-${borderRadius || 'sm'})` }
+          ? {
+              borderRadius: `var(--mantine-radius-${borderRadius || 'sm'})`,
+              // `clip-path` clips the rounded corners without making
+              // `.root` a scroll containing block — using `overflow:
+              // hidden` here would break `position: sticky` on the
+              // table header (it would pin to `.root` instead of the
+              // page viewport).
+              clipPath: `inset(0 round var(--mantine-radius-${borderRadius || 'sm'}))`,
+            }
           : undefined,
       })}
       tabIndex={kbEnabled ? 0 : undefined}

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -1095,8 +1095,10 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
               // `.root` a scroll containing block — using `overflow:
               // hidden` here would break `position: sticky` on the
               // table header (it would pin to `.root` instead of the
-              // page viewport).
-              clipPath: `inset(0 round var(--mantine-radius-${borderRadius || 'sm'}))`,
+              // page viewport). The `padding-box` reference keeps the
+              // clip strictly inside the wrapper's border so the border
+              // line is rendered intact at the corners.
+              clipPath: `inset(0 round var(--mantine-radius-${borderRadius || 'sm'})) padding-box`,
             }
           : undefined,
       })}

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -822,13 +822,6 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
                 getStyles={() => getStyles('resizeHandle')}
               />
             )}
-
-          {/* Pinned-column edge shadow — only on the last sticky-left and the
-              first sticky-right column. CSS variables on the table root drive
-              the opacity transition in response to scroll. */}
-          {shadowSide && (
-            <span {...getStyles('stickyColumnShadow')} data-side={shadowSide} aria-hidden />
-          )}
         </Table.Th>
       );
     },
@@ -896,10 +889,6 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
 
       const cellInner = stickySide ? <div style={ellipsisStyle}>{cellContent}</div> : cellContent;
 
-      const shadowEl = shadowSide ? (
-        <span {...getStyles('stickyColumnShadow')} data-side={shadowSide} aria-hidden />
-      ) : null;
-
       // See the matching comment in renderHeaderCell: pin both `left` and
       // `right` explicitly so a stale class rule cannot leave both at `0`.
       const stickyPositionStyle =
@@ -943,7 +932,6 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
           data-sticky-shadow={shadowSide}
         >
           {cellInner}
-          {shadowEl}
         </Table.Td>
       );
     },

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -680,12 +680,20 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
   });
 
   // Dynamic table-layout (resolves Issue #4)
+  // While resize is active we explicitly use `auto` even though the
+  // intuition is "lock to fixed for stability". Reason: under
+  // `table-layout: fixed` Chromium re-distributes track widths evenly
+  // when any cell is `position: sticky` (the whole pinned-column case)
+  // and the explicit `width` / `min-width` / `max-width` set inline by
+  // `useColumnResize` is silently ignored. With `auto` the inline cell
+  // widths are honored, and stability is preserved by the locked table
+  // width returned from `getTableStyle()`.
   const tableLayout = useMemo(() => {
     if (layout) {
       return layout;
     }
     if (isResizeActive) {
-      return 'fixed' as const;
+      return 'auto' as const;
     }
     return undefined;
   }, [layout, isResizeActive]);

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -1141,27 +1141,32 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
       <div
         {...getStyles('scrollViewport')}
         style={
-          /* The wrapper carries `clip-path` (when `withTableBorder` is
-             set) so the table content is clipped to the rounded shape
-             of `.root`. The border lives on `.root` and is left
-             untouched by this clip, so the corners stay crisp.
-             `clip-path` does NOT establish a scroll containing block,
-             which keeps `position: sticky` on the table header working
-             correctly relative to the page viewport.
+          /* When `scrollProps` is set, this `<div>` becomes the native
+             scroll viewport (`overflow: auto` + `maxHeight`). When
+             `withTableBorder` is set, it also carries the `clip-path`
+             that clips the table content to the wrapper's rounded
+             corners (using `clip-path` instead of `overflow: hidden`
+             keeps `.root` from becoming a sticky containing block,
+             which would break `stickyHeader`).
 
-             In `scrollEnabled` mode this same `<div>` becomes the
-             native scroll viewport; the `clip-path` continues to
-             clip the rounded corners during horizontal/vertical
-             scroll so the wrapper's rounded border always frames the
-             scrolled content. */
-          {
-            ...(scrollEnabled ? { overflow: 'auto', maxHeight: scrollProps?.maxHeight } : null),
-            ...(withTableBorder
-              ? {
-                  clipPath: `inset(0 round ${getRadius(borderRadius ?? 'sm')})`,
-                }
-              : null),
-          }
+             When neither is active, fall back to `display: contents`
+             so the wrapper is invisible to layout — the `<table>`
+             then relates directly to `.root`, identical to the
+             pre-`scrollProps` rendering. Without this fallback, the
+             extra block-level `<div>` would subtly change column
+             distribution for resize / Finder / Standard modes
+             (because `<table>` width would resolve against the inner
+             div instead of `.root`). */
+          scrollEnabled || withTableBorder
+            ? {
+                ...(scrollEnabled
+                  ? { overflow: 'auto', maxHeight: scrollProps?.maxHeight }
+                  : null),
+                ...(withTableBorder
+                  ? { clipPath: `inset(0 round ${getRadius(borderRadius ?? 'sm')})` }
+                  : null),
+              }
+            : { display: 'contents' }
         }
       >
         <Table

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -773,7 +773,7 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
               left: 0,
               right: 'auto' as const,
               zIndex: 11,
-              // Allow the shadow span to extend outside the cell border.
+              // Allow the shadow `::after` pseudo to extend outside the cell border.
               overflow: 'visible' as const,
             }
           : stickySide === 'right'

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -421,15 +421,19 @@ const varsResolver = createVarsResolver<ListViewTableFactory>((_, { selectedRowC
     '--list-view-cell-font-size': undefined,
     '--list-view-cell-font-weight': undefined,
     '--list-view-selected-row-color': selectedRowColor || undefined,
-    // Sticky-column shadow vars — `*-opacity` are written by `useStickyShadow`
-    // on every horizontal scroll. `*-color` and `*-width` use CSS fallbacks
-    // (declared via `var(name, fallback)` in the stylesheet) so consumers can
-    // override them through `vars` or external CSS without us hard-coding a
-    // value here.
+    // Sticky-column shadow vars — `*-opacity` are written by
+    // `useStickyShadow` on every horizontal scroll. `*-color` and
+    // `*-width` use CSS fallbacks (declared via `var(name, fallback)` in
+    // the stylesheet) so consumers can override them through `vars` or
+    // external CSS without us hard-coding a value here.
     '--lvt-shadow-color': undefined,
     '--lvt-shadow-width': undefined,
     '--lvt-shadow-left-opacity': undefined,
     '--lvt-shadow-right-opacity': undefined,
+    // Sticky-header shadow opacity is written by `useStickyHeaderShadow`
+    // on vertical scroll. To customize the shadow shape/color, override
+    // `.mantine-ListViewTable-header` via the Styles API.
+    '--lvt-header-shadow-opacity': undefined,
   },
 }));
 

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -697,18 +697,25 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
             ? 'right'
             : undefined;
 
+      // Always pin both `left` and `right` explicitly so the renderer never
+      // ends up with a stale value from a class rule. With both `left: 0` and
+      // `right: 0` set simultaneously the browser stretches the sticky cell
+      // and the underlying scroll content briefly leaks at the edges during
+      // scroll, which is exactly the artifact we are guarding against here.
       const stickyPositionStyle =
         stickySide === 'left'
           ? {
               position: 'sticky' as const,
               left: 0,
+              right: 'auto' as const,
               zIndex: 11,
-              // Allow the shadow ::after to extend outside the cell border.
+              // Allow the shadow span to extend outside the cell border.
               overflow: 'visible' as const,
             }
           : stickySide === 'right'
             ? {
                 position: 'sticky' as const,
+                left: 'auto' as const,
                 right: 0,
                 zIndex: 11,
                 overflow: 'visible' as const,
@@ -893,11 +900,25 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
         <span {...getStyles('stickyColumnShadow')} data-side={shadowSide} aria-hidden />
       ) : null;
 
+      // See the matching comment in renderHeaderCell: pin both `left` and
+      // `right` explicitly so a stale class rule cannot leave both at `0`.
       const stickyPositionStyle =
         stickySide === 'left'
-          ? { position: 'sticky' as const, left: 0, zIndex: 10, overflow: 'visible' as const }
+          ? {
+              position: 'sticky' as const,
+              left: 0,
+              right: 'auto' as const,
+              zIndex: 10,
+              overflow: 'visible' as const,
+            }
           : stickySide === 'right'
-            ? { position: 'sticky' as const, right: 0, zIndex: 10, overflow: 'visible' as const }
+            ? {
+                position: 'sticky' as const,
+                left: 'auto' as const,
+                right: 0,
+                zIndex: 10,
+                overflow: 'visible' as const,
+              }
             : {
                 whiteSpace: column.noWrap || noWrap ? ('nowrap' as const) : undefined,
                 textOverflow: column.ellipsis ? ('ellipsis' as const) : undefined,

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -372,7 +372,6 @@ const varsResolver = createVarsResolver<ListViewTableFactory>((_, { selectedRowC
     '--list-view-cell-font-size': undefined,
     '--list-view-cell-font-weight': undefined,
     '--list-view-selected-row-color': selectedRowColor || undefined,
-    '--list-view-sticky-blur': undefined,
     // Sticky-column shadow vars — `*-opacity` are written by `useStickyShadow`
     // on every horizontal scroll. `*-color` and `*-width` use CSS fallbacks
     // (declared via `var(name, fallback)` in the stylesheet) so consumers can

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -593,6 +593,7 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
   });
 
   const {
+    columnWidths,
     isResizeActive,
     getColumnStyle,
     getTableStyle,
@@ -1208,6 +1209,26 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
           {...tableProps}
           ref={tableRef}
         >
+          {/* Resize-active sticky tables get an explicit `<colgroup>`
+              because Chromium ignores inline `<th>` widths on
+              `position: sticky` cells under `table-layout: fixed` —
+              `<col>` widths are honored regardless. The colgroup is
+              gated on `hasStickyColumns` so non-sticky resize keeps
+              the original `<th>`-only path (preserving the exact
+              Finder/Standard column distribution). */}
+          {isResizeActive && hasStickyColumns && (
+            <colgroup>
+              {visibleColumns.map((column) => {
+                const w = columnWidths[column.key as string];
+                return (
+                  <col
+                    key={column.key as React.Key}
+                    style={w ? { width: `${w}px` } : undefined}
+                  />
+                );
+              })}
+            </colgroup>
+          )}
           <Table.Thead
             {...getStyles('header')}
             onContextMenu={enableColumnVisibilityToggle ? handleHeaderContextMenu : undefined}

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -1160,9 +1160,7 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
              div instead of `.root`). */
           scrollEnabled || withTableBorder
             ? {
-                ...(scrollEnabled
-                  ? { overflow: 'auto', maxHeight: scrollProps?.maxHeight }
-                  : null),
+                ...(scrollEnabled ? { overflow: 'auto', maxHeight: scrollProps?.maxHeight } : null),
                 ...(withTableBorder
                   ? { clipPath: `inset(0 round ${getRadius(borderRadius ?? 'sm')})` }
                   : null),
@@ -1180,9 +1178,7 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
               // Finder/Standard resize and let the CSS-class
               // `min-width: 100%` take over (which forces the table back
               // to the parent width and redistributes columns evenly).
-              ...(scrollProps?.minWidth !== undefined
-                ? { minWidth: scrollProps.minWidth }
-                : null),
+              ...(scrollProps?.minWidth !== undefined ? { minWidth: scrollProps.minWidth } : null),
             },
           })}
           /* Border lives on the outer `<Box>` wrapper (see CSS rule on
@@ -1221,10 +1217,7 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
               {visibleColumns.map((column) => {
                 const w = columnWidths[column.key as string];
                 return (
-                  <col
-                    key={column.key as React.Key}
-                    style={w ? { width: `${w}px` } : undefined}
-                  />
+                  <col key={column.key as React.Key} style={w ? { width: `${w}px` } : undefined} />
                 );
               })}
             </colgroup>

--- a/package/src/ListViewTable.tsx
+++ b/package/src/ListViewTable.tsx
@@ -1074,30 +1074,29 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
   }
 
   // === Render: Normal table ===
-  // When `scrollProps` is set, ListViewTable owns the scroll context: an
-  // outer non-scrolling `<Box>` holds the border + border-radius, and an
-  // inner viewport `<div>` does native horizontal/vertical scrolling. This
-  // is the recommended setup for sticky columns + `withTableBorder` because
-  // the border stays fixed regardless of scroll position. When `scrollProps`
-  // is not set we render the `<Table>` inline and let the consumer wrap us
-  // in `Mantine.Table.ScrollContainer` (or any other scroller) — Mantine's
-  // native `<table>` border then carries the border, but it scrolls with
-  // the table content.
+  // The outer `<Box>` always owns `withTableBorder` + `borderRadius`. When
+  // `scrollProps` is set, the inner `<div>` becomes the scroll viewport
+  // (native horizontal/vertical scrolling) so the border on the wrapper
+  // stays fixed regardless of scroll position — the recommended setup for
+  // sticky columns. When `scrollProps` is not set, the inner `<div>` uses
+  // `display: contents` (invisible to layout), so the table behaves
+  // exactly as if it were a direct child of the outer `<Box>`. Consumers
+  // can still wrap the component in `Mantine.Table.ScrollContainer` or any
+  // other scroller — but with `scrollProps` the border stays fixed.
   const scrollEnabled = !!scrollProps;
   return (
     <Box
       {...getStyles('root', {
         className: responsiveClassName,
-        style:
-          scrollEnabled && withTableBorder
-            ? { borderRadius: `var(--mantine-radius-${borderRadius || 'sm'})` }
-            : undefined,
+        style: withTableBorder
+          ? { borderRadius: `var(--mantine-radius-${borderRadius || 'sm'})` }
+          : undefined,
       })}
       tabIndex={kbEnabled ? 0 : undefined}
       onKeyDown={kbEnabled ? handleKeyDown : undefined}
       data-dragging={draggedColumn !== null ? 'true' : undefined}
       data-resizing={isResizeActive ? 'true' : undefined}
-      data-with-table-border={scrollEnabled && withTableBorder ? 'true' : undefined}
+      data-with-table-border={withTableBorder ? 'true' : undefined}
       data-with-scroll={scrollEnabled ? 'true' : undefined}
       {...others}
     >
@@ -1119,7 +1118,12 @@ export const ListViewTable = factory<ListViewTableFactory>((_props) => {
           {...getStyles('table', {
             style: { ...getTableStyle(), minWidth: scrollProps?.minWidth },
           })}
-          withTableBorder={scrollEnabled ? false : withTableBorder}
+          /* Border lives on the outer `<Box>` wrapper (see CSS rule on
+             `.root[data-with-table-border='true']`) so it stays fixed
+             regardless of horizontal scroll position and respects
+             `borderRadius`. Mantine's native border on the `<table>` is
+             always disabled here. */
+          withTableBorder={false}
           withColumnBorders={withColumnBorders}
           withRowBorders={withRowBorders}
           striped={striped}

--- a/package/src/hooks/index.ts
+++ b/package/src/hooks/index.ts
@@ -21,3 +21,6 @@ export type {
   UseColumnVisibilityOptions,
   UseColumnVisibilityReturn,
 } from './use-column-visibility';
+
+export { useStickyShadow } from './use-sticky-shadow';
+export type { UseStickyShadowOptions } from './use-sticky-shadow';

--- a/package/src/hooks/use-column-resize.ts
+++ b/package/src/hooks/use-column-resize.ts
@@ -145,11 +145,17 @@ export function useColumnResize({
       event.preventDefault();
       event.stopPropagation();
 
-      // On first resize, snapshot all widths and enter pixel mode
-      let currentWidths = columnWidths;
+      // Snapshot the *current* rendered widths from the DOM at the
+      // start of every drag. Doing it only on the first drag
+      // (`!isResizeActive`) leaves stale state behind when the user
+      // switches `resizeMode` (e.g. standard → finder) or when other
+      // columns reflowed between drags, and the next drag would then
+      // use those stale widths as its `leftStartWidth` baseline —
+      // producing visibly wrong deltas. Reading from the DOM each
+      // time keeps the resize math in sync with what the user sees.
+      const currentWidths = snapshotColumnWidths();
+      setColumnWidths(currentWidths);
       if (!isResizeActive) {
-        currentWidths = snapshotColumnWidths();
-        setColumnWidths(currentWidths);
         setIsResizeActive(true);
       }
 

--- a/package/src/hooks/use-column-resize.ts
+++ b/package/src/hooks/use-column-resize.ts
@@ -93,20 +93,10 @@ export function useColumnResize({
   const getColumnStyle = useCallback(
     (col: ListViewTableColumn, _idx: number): React.CSSProperties => {
       if (isResizeActive && columnWidths[col.key as string]) {
-        // Pin both `min-width` and `max-width` to the resize width.
-        // Chromium ignores explicit `width` on table cells with
-        // `position: sticky` when `table-layout: fixed` is in effect
-        // (the auto-distributed track width wins), so without these the
-        // pinned-column resize would silently redistribute back to the
-        // even split. The resize logic already clamps against the
-        // column's `minWidth` / `maxWidth` constraints before writing
-        // `columnWidths[key]`, so locking min/max to the same value
-        // here is safe.
-        const width = `${columnWidths[col.key as string]}px`;
         return {
-          width,
-          minWidth: width,
-          maxWidth: width,
+          width: `${columnWidths[col.key as string]}px`,
+          minWidth: resolveSize(col.minWidth),
+          maxWidth: resolveSize(col.maxWidth),
         };
       }
       return {

--- a/package/src/hooks/use-column-resize.ts
+++ b/package/src/hooks/use-column-resize.ts
@@ -145,17 +145,11 @@ export function useColumnResize({
       event.preventDefault();
       event.stopPropagation();
 
-      // Snapshot the *current* rendered widths from the DOM at the
-      // start of every drag. Doing it only on the first drag
-      // (`!isResizeActive`) leaves stale state behind when the user
-      // switches `resizeMode` (e.g. standard → finder) or when other
-      // columns reflowed between drags, and the next drag would then
-      // use those stale widths as its `leftStartWidth` baseline —
-      // producing visibly wrong deltas. Reading from the DOM each
-      // time keeps the resize math in sync with what the user sees.
-      const currentWidths = snapshotColumnWidths();
-      setColumnWidths(currentWidths);
+      // On first resize, snapshot all widths and enter pixel mode
+      let currentWidths = columnWidths;
       if (!isResizeActive) {
+        currentWidths = snapshotColumnWidths();
+        setColumnWidths(currentWidths);
         setIsResizeActive(true);
       }
 

--- a/package/src/hooks/use-column-resize.ts
+++ b/package/src/hooks/use-column-resize.ts
@@ -93,10 +93,20 @@ export function useColumnResize({
   const getColumnStyle = useCallback(
     (col: ListViewTableColumn, _idx: number): React.CSSProperties => {
       if (isResizeActive && columnWidths[col.key as string]) {
+        // Pin both `min-width` and `max-width` to the resize width.
+        // Chromium ignores explicit `width` on table cells with
+        // `position: sticky` when `table-layout: fixed` is in effect
+        // (the auto-distributed track width wins), so without these the
+        // pinned-column resize would silently redistribute back to the
+        // even split. The resize logic already clamps against the
+        // column's `minWidth` / `maxWidth` constraints before writing
+        // `columnWidths[key]`, so locking min/max to the same value
+        // here is safe.
+        const width = `${columnWidths[col.key as string]}px`;
         return {
-          width: `${columnWidths[col.key as string]}px`,
-          minWidth: resolveSize(col.minWidth),
-          maxWidth: resolveSize(col.maxWidth),
+          width,
+          minWidth: width,
+          maxWidth: width,
         };
       }
       return {

--- a/package/src/hooks/use-sticky-header-shadow.test.tsx
+++ b/package/src/hooks/use-sticky-header-shadow.test.tsx
@@ -1,0 +1,64 @@
+import React, { useRef } from 'react';
+import { render } from '@mantine-tests/core';
+import { useStickyHeaderShadow } from './use-sticky-header-shadow';
+
+function Host({
+  enabled = true,
+  initialScrollTop = 0,
+}: {
+  enabled?: boolean;
+  initialScrollTop?: number;
+}) {
+  const ref = useRef<HTMLTableElement | null>(null);
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+  // Pre-set `scrollTop` on the scroller *before* the hook's effect
+  // runs by attaching a `useRef` callback. The hook reads `scrollTop`
+  // synchronously inside its initial `update()`, so this lets us seed
+  // the container-scrolled detection branch deterministically.
+  const seedScroll = (el: HTMLDivElement | null) => {
+    scrollerRef.current = el;
+    if (el && initialScrollTop) {
+      el.scrollTop = initialScrollTop;
+    }
+  };
+  useStickyHeaderShadow({ tableRef: ref, enabled });
+  return (
+    <div ref={seedScroll} data-testid="scroller" style={{ overflowY: 'auto', height: 100 }}>
+      <table ref={ref} data-testid="table">
+        <thead>
+          <tr>
+            <th>H</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>row</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+describe('useStickyHeaderShadow', () => {
+  it('writes initial 0 opacity when nothing has been scrolled', () => {
+    const { getByTestId } = render(<Host />);
+    const table = getByTestId('table') as HTMLElement;
+    expect(table.style.getPropertyValue('--lvt-header-shadow-opacity')).toBe('0');
+  });
+
+  it('does nothing when `enabled` is false', () => {
+    const { getByTestId } = render(<Host enabled={false} />);
+    const table = getByTestId('table') as HTMLElement;
+    expect(table.style.getPropertyValue('--lvt-header-shadow-opacity')).toBe('');
+  });
+
+  it('writes 1 in container-scrolled mode when the scroller already has scrollTop > 0', () => {
+    // Container-scrolled branch: the hook checks `scroller.scrollTop`
+    // (not the thead position), so a non-zero initial scrollTop should
+    // produce an immediate `1`.
+    const { getByTestId } = render(<Host initialScrollTop={50} />);
+    const table = getByTestId('table') as HTMLElement;
+    expect(table.style.getPropertyValue('--lvt-header-shadow-opacity')).toBe('1');
+  });
+});

--- a/package/src/hooks/use-sticky-header-shadow.ts
+++ b/package/src/hooks/use-sticky-header-shadow.ts
@@ -63,8 +63,6 @@ export function useStickyHeaderShadow({
       return;
     }
 
-    const offsetN = typeof offset === 'number' ? offset : parseFloat(String(offset)) || 0;
-
     const scroller = findVerticalScrollAncestor(table);
     const isWindow = scroller === window;
 
@@ -81,9 +79,14 @@ export function useStickyHeaderShadow({
       if (isWindow) {
         // Page-scrolled mode: rely on the thead's viewport position to
         // detect when sticky has taken over. Before the page scrolls
-        // far enough, `thead.top > offsetN`; once stuck, they match.
+        // far enough, `thead.top > resolvedOffset`; once stuck, they
+        // match. We read the resolved sticky offset from
+        // `getComputedStyle(thead).top` — this is always in pixels,
+        // regardless of whether the user supplied a number, `'2rem'`,
+        // `'1em'`, or any other CSS length to `stickyHeaderOffset`.
+        const resolvedOffset = parseFloat(getComputedStyle(thead).top) || 0;
         const rectTop = thead.getBoundingClientRect().top;
-        stuck = Math.abs(rectTop - offsetN) < 1;
+        stuck = Math.abs(rectTop - resolvedOffset) < 1;
       } else {
         // Container-scrolled mode: the thead is permanently at the top
         // of the viewport, so the only useful signal is "has the user

--- a/package/src/hooks/use-sticky-header-shadow.ts
+++ b/package/src/hooks/use-sticky-header-shadow.ts
@@ -37,13 +37,13 @@ function findVerticalScrollAncestor(el: HTMLElement): HTMLElement | Window {
  * via `requestAnimationFrame`.
  *
  * Detection compares `thead.getBoundingClientRect().top` to the
- * resolved `stickyHeaderOffset`: when they match (within a 1px
- * tolerance) the header is stuck. This is reliable across both modes:
- * sticky-to-page (no `scrollProps`) and sticky-to-internal-viewport
- * (with `scrollProps.maxHeight`), because the rect is always relative
- * to the viewport while the offset is page-relative or
- * scroller-relative depending on the sticky containing block — both
- * collapse to the same numeric `top` when stuck.
+ * resolved sticky position. When the scroll ancestor is the page,
+ * the sticky position is `stickyHeaderOffset` (in viewport coords).
+ * When the scroll ancestor is an element (Mantine `ScrollArea`,
+ * `scrollProps.maxHeight`, or any custom container), the sticky
+ * position is `scrollerRect.top + stickyHeaderOffset`. The hook
+ * normalizes both into the same comparison so the shadow fades in
+ * regardless of which container the table is scrolling inside.
  */
 export function useStickyHeaderShadow({
   tableRef,
@@ -72,10 +72,13 @@ export function useStickyHeaderShadow({
       }
       const rect = thead.getBoundingClientRect();
       // The thead is "stuck" when its top sits exactly at the resolved
-      // sticky offset. While unstuck (page not yet scrolled enough) the
-      // top is below the offset; once sticky releases at the bottom of
-      // its containing block, the top moves up past the offset.
-      const stuck = Math.abs(rect.top - offsetN) < 1;
+      // sticky position. The sticky position is the offset relative to
+      // the scroll containing block: the viewport itself when the
+      // scroller is `window`, or the scroller's own top edge otherwise
+      // (Mantine `ScrollArea`, `scrollProps.maxHeight`, etc.).
+      const scrollerTop = isWindow ? 0 : (scroller as HTMLElement).getBoundingClientRect().top;
+      const stickyTop = scrollerTop + offsetN;
+      const stuck = Math.abs(rect.top - stickyTop) < 1;
       const val = stuck ? 1 : 0;
       if (val !== lastVal) {
         table.style.setProperty('--lvt-header-shadow-opacity', String(val));

--- a/package/src/hooks/use-sticky-header-shadow.ts
+++ b/package/src/hooks/use-sticky-header-shadow.ts
@@ -1,0 +1,126 @@
+import { useEffect } from 'react';
+
+export interface UseStickyHeaderShadowOptions {
+  /** Ref to the table element that will receive the CSS variable */
+  tableRef: React.RefObject<HTMLElement | null>;
+  /** Skip the effect entirely when `stickyHeader` is not enabled */
+  enabled?: boolean;
+  /** Same value as `stickyHeaderOffset` on the component */
+  offset?: number | string;
+}
+
+function findVerticalScrollAncestor(el: HTMLElement): HTMLElement | Window {
+  let cur: HTMLElement | null = el.parentElement;
+  while (cur) {
+    const cs = getComputedStyle(cur);
+    if (cs.overflowY !== 'visible') {
+      return cur;
+    }
+    cur = cur.parentElement;
+  }
+  return window;
+}
+
+/**
+ * Drives the drop-shadow that fades in below a `stickyHeader` thead while
+ * the user is scrolling content underneath it.
+ *
+ * Writes a single CSS variable on the table root:
+ *
+ * - `--lvt-header-shadow-opacity`: `1` when the thead is currently
+ *   "stuck" at `stickyHeaderOffset`, `0` while it sits in its natural
+ *   position (or after sticky has released because the table itself
+ *   has scrolled past).
+ *
+ * The CSS layer reads this variable to fade a soft `box-shadow` on the
+ * `<thead>` — no React re-renders during scroll. Updates are throttled
+ * via `requestAnimationFrame`.
+ *
+ * Detection compares `thead.getBoundingClientRect().top` to the
+ * resolved `stickyHeaderOffset`: when they match (within a 1px
+ * tolerance) the header is stuck. This is reliable across both modes:
+ * sticky-to-page (no `scrollProps`) and sticky-to-internal-viewport
+ * (with `scrollProps.maxHeight`), because the rect is always relative
+ * to the viewport while the offset is page-relative or
+ * scroller-relative depending on the sticky containing block — both
+ * collapse to the same numeric `top` when stuck.
+ */
+export function useStickyHeaderShadow({
+  tableRef,
+  enabled = true,
+  offset = 0,
+}: UseStickyHeaderShadowOptions): void {
+  useEffect(() => {
+    const table = tableRef.current;
+    if (!enabled || !table) {
+      return;
+    }
+
+    const offsetN = typeof offset === 'number' ? offset : parseFloat(String(offset)) || 0;
+
+    const scroller = findVerticalScrollAncestor(table);
+    const isWindow = scroller === window;
+
+    let rafId: number | null = null;
+    let lastVal = -1;
+
+    const update = () => {
+      rafId = null;
+      const thead = table.querySelector('thead') as HTMLElement | null;
+      if (!thead) {
+        return;
+      }
+      const rect = thead.getBoundingClientRect();
+      // The thead is "stuck" when its top sits exactly at the resolved
+      // sticky offset. While unstuck (page not yet scrolled enough) the
+      // top is below the offset; once sticky releases at the bottom of
+      // its containing block, the top moves up past the offset.
+      const stuck = Math.abs(rect.top - offsetN) < 1;
+      const val = stuck ? 1 : 0;
+      if (val !== lastVal) {
+        table.style.setProperty('--lvt-header-shadow-opacity', String(val));
+        lastVal = val;
+      }
+    };
+
+    const onScrollOrResize = () => {
+      if (rafId !== null) {
+        return;
+      }
+      rafId = requestAnimationFrame(update);
+    };
+
+    update();
+    scroller.addEventListener('scroll', onScrollOrResize, { passive: true });
+    if (!isWindow) {
+      // Listen to window scroll too — when the wrapper has its own
+      // overflow but its parent is also scrollable (or the user just
+      // scrolls the page), we still need to recompute.
+      window.addEventListener('scroll', onScrollOrResize, { passive: true });
+    }
+    window.addEventListener('resize', onScrollOrResize, { passive: true });
+
+    let resizeObserver: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(() => {
+        onScrollOrResize();
+      });
+      resizeObserver.observe(table);
+      if (!isWindow) {
+        resizeObserver.observe(scroller as HTMLElement);
+      }
+    }
+
+    return () => {
+      scroller.removeEventListener('scroll', onScrollOrResize);
+      if (!isWindow) {
+        window.removeEventListener('scroll', onScrollOrResize);
+      }
+      window.removeEventListener('resize', onScrollOrResize);
+      resizeObserver?.disconnect();
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+      }
+    };
+  }, [tableRef, enabled, offset]);
+}

--- a/package/src/hooks/use-sticky-header-shadow.ts
+++ b/package/src/hooks/use-sticky-header-shadow.ts
@@ -36,14 +36,21 @@ function findVerticalScrollAncestor(el: HTMLElement): HTMLElement | Window {
  * `<thead>` — no React re-renders during scroll. Updates are throttled
  * via `requestAnimationFrame`.
  *
- * Detection compares `thead.getBoundingClientRect().top` to the
- * resolved sticky position. When the scroll ancestor is the page,
- * the sticky position is `stickyHeaderOffset` (in viewport coords).
- * When the scroll ancestor is an element (Mantine `ScrollArea`,
- * `scrollProps.maxHeight`, or any custom container), the sticky
- * position is `scrollerRect.top + stickyHeaderOffset`. The hook
- * normalizes both into the same comparison so the shadow fades in
- * regardless of which container the table is scrolling inside.
+ * Detection differs by scroll container:
+ *
+ * - **Page-scrolled** (no fixed-height container): the thead is at its
+ *   natural position until the page scrolls enough to engage sticky.
+ *   The hook compares `thead.getBoundingClientRect().top` to
+ *   `stickyHeaderOffset` — they only match once sticky takes over.
+ * - **Container-scrolled** (Mantine `ScrollArea`,
+ *   `scrollProps.maxHeight`, or any custom scroller): the thead's
+ *   natural position already coincides with the sticky position
+ *   (because the table starts at the top of the viewport), so a
+ *   position check would always be true. Instead the hook checks
+ *   `scroller.scrollTop > 0` — i.e., the user has actually scrolled
+ *   content underneath the thead. This mirrors the visual cue users
+ *   expect: the shadow only appears once there is content to "hide
+ *   behind" the header.
  */
 export function useStickyHeaderShadow({
   tableRef,
@@ -70,15 +77,20 @@ export function useStickyHeaderShadow({
       if (!thead) {
         return;
       }
-      const rect = thead.getBoundingClientRect();
-      // The thead is "stuck" when its top sits exactly at the resolved
-      // sticky position. The sticky position is the offset relative to
-      // the scroll containing block: the viewport itself when the
-      // scroller is `window`, or the scroller's own top edge otherwise
-      // (Mantine `ScrollArea`, `scrollProps.maxHeight`, etc.).
-      const scrollerTop = isWindow ? 0 : (scroller as HTMLElement).getBoundingClientRect().top;
-      const stickyTop = scrollerTop + offsetN;
-      const stuck = Math.abs(rect.top - stickyTop) < 1;
+      let stuck: boolean;
+      if (isWindow) {
+        // Page-scrolled mode: rely on the thead's viewport position to
+        // detect when sticky has taken over. Before the page scrolls
+        // far enough, `thead.top > offsetN`; once stuck, they match.
+        const rectTop = thead.getBoundingClientRect().top;
+        stuck = Math.abs(rectTop - offsetN) < 1;
+      } else {
+        // Container-scrolled mode: the thead is permanently at the top
+        // of the viewport, so the only useful signal is "has the user
+        // scrolled the inner content?". `scrollTop > 0` means there is
+        // content currently hidden above the thead.
+        stuck = (scroller as HTMLElement).scrollTop > 0;
+      }
       const val = stuck ? 1 : 0;
       if (val !== lastVal) {
         table.style.setProperty('--lvt-header-shadow-opacity', String(val));

--- a/package/src/hooks/use-sticky-shadow.test.tsx
+++ b/package/src/hooks/use-sticky-shadow.test.tsx
@@ -1,0 +1,39 @@
+import React, { useRef } from 'react';
+import { render } from '@mantine-tests/core';
+import { useStickyShadow } from './use-sticky-shadow';
+
+function Host({ enabled = true }: { enabled?: boolean }) {
+  const ref = useRef<HTMLTableElement | null>(null);
+  useStickyShadow({ tableRef: ref, enabled });
+  return (
+    // The wrapper has overflow-x: scroll so the hook attaches its scroll
+    // listener here instead of on `window`.
+    <div data-testid="scroller" style={{ overflowX: 'scroll', width: 200 }}>
+      <table ref={ref} data-testid="table">
+        <tbody>
+          <tr>
+            <td style={{ width: 1000 }}>wide cell</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+describe('useStickyShadow', () => {
+  it('writes initial 0 opacity values when the table is not yet scrolled', () => {
+    const { getByTestId } = render(<Host />);
+    const table = getByTestId('table') as HTMLElement;
+    // The hook runs an initial update on mount (synchronous, not via rAF).
+    expect(table.style.getPropertyValue('--lvt-shadow-left-opacity')).toBe('0');
+    expect(table.style.getPropertyValue('--lvt-shadow-right-opacity')).toBe('0');
+  });
+
+  it('does nothing when `enabled` is false', () => {
+    const { getByTestId } = render(<Host enabled={false} />);
+    const table = getByTestId('table') as HTMLElement;
+    // Hook bails early; no CSS variables are written.
+    expect(table.style.getPropertyValue('--lvt-shadow-left-opacity')).toBe('');
+    expect(table.style.getPropertyValue('--lvt-shadow-right-opacity')).toBe('');
+  });
+});

--- a/package/src/hooks/use-sticky-shadow.ts
+++ b/package/src/hooks/use-sticky-shadow.ts
@@ -39,10 +39,10 @@ function findHorizontalScrollAncestor(el: HTMLElement): HTMLElement | Window {
  * these variables to fade their gradient in and out — no React re-renders
  * on scroll. Updates are throttled via `requestAnimationFrame`.
  *
- * RTL: `scrollLeft` is negative on modern browsers under `direction: rtl`,
- * so the absolute value is used and the meaning of "left" / "right"
- * flips with the writing direction (handled at the CSS layer via
- * `[dir="rtl"]` rules — the hook just reports the magnitude).
+ * Note: the hook reports the magnitude of `scrollLeft` (which is negative
+ * on modern browsers under `direction: rtl`); RTL-specific styling is
+ * not currently shipped — consumers using `dir="rtl"` should override the
+ * shadow CSS as needed.
  */
 export function useStickyShadow({ tableRef, enabled = true }: UseStickyShadowOptions): void {
   useEffect(() => {

--- a/package/src/hooks/use-sticky-shadow.ts
+++ b/package/src/hooks/use-sticky-shadow.ts
@@ -1,0 +1,134 @@
+import { useEffect } from 'react';
+
+export interface UseStickyShadowOptions {
+  /** Ref to the table element that will receive the CSS variables */
+  tableRef: React.RefObject<HTMLElement | null>;
+  /** Skip the effect entirely when the table has no sticky columns */
+  enabled?: boolean;
+}
+
+function findHorizontalScrollAncestor(el: HTMLElement): HTMLElement | Window {
+  let cur: HTMLElement | null = el.parentElement;
+  while (cur) {
+    const cs = getComputedStyle(cur);
+    // Any non-`visible` horizontal overflow makes the element a scroll
+    // boundary. We accept `hidden` too because Mantine's `ScrollArea`
+    // viewport — the actual element whose `scrollLeft` changes when the
+    // user drags the custom scrollbar — uses `overflow-x: hidden` while
+    // still being programmatically scrollable. We must not skip it.
+    if (cs.overflowX !== 'visible') {
+      return cur;
+    }
+    cur = cur.parentElement;
+  }
+  return window;
+}
+
+/**
+ * Drives the gradient shadow on pinned (sticky) columns.
+ *
+ * On every horizontal scroll of the closest scrollable ancestor (or the
+ * window if none), writes two CSS custom properties on the table root:
+ *
+ * - `--lvt-shadow-left-opacity`: `1` when there is content scrolled past
+ *   the left edge, `0` otherwise.
+ * - `--lvt-shadow-right-opacity`: `1` when there is content extending
+ *   beyond the right edge, `0` otherwise.
+ *
+ * The CSS pseudo-elements on `.stickyColumn[data-sticky-shadow]` read
+ * these variables to fade their gradient in and out — no React re-renders
+ * on scroll. Updates are throttled via `requestAnimationFrame`.
+ *
+ * RTL: `scrollLeft` is negative on modern browsers under `direction: rtl`,
+ * so the absolute value is used and the meaning of "left" / "right"
+ * flips with the writing direction (handled at the CSS layer via
+ * `[dir="rtl"]` rules — the hook just reports the magnitude).
+ */
+export function useStickyShadow({ tableRef, enabled = true }: UseStickyShadowOptions): void {
+  useEffect(() => {
+    const table = tableRef.current;
+    if (!enabled || !table) {
+      return;
+    }
+
+    const scroller = findHorizontalScrollAncestor(table);
+    const isWindow = scroller === window;
+
+    let rafId: number | null = null;
+    let lastLeft = -1;
+    let lastRight = -1;
+
+    const update = () => {
+      rafId = null;
+
+      let scrollLeft: number;
+      let scrollWidth: number;
+      let clientWidth: number;
+
+      if (isWindow) {
+        scrollLeft = window.scrollX;
+        scrollWidth = document.documentElement.scrollWidth;
+        clientWidth = window.innerWidth;
+      } else {
+        const el = scroller as HTMLElement;
+        scrollLeft = el.scrollLeft;
+        scrollWidth = el.scrollWidth;
+        clientWidth = el.clientWidth;
+      }
+
+      const absScrollLeft = Math.abs(scrollLeft);
+      const remaining = scrollWidth - clientWidth - absScrollLeft;
+      // 1px tolerance for sub-pixel rounding (browsers often report fractional widths)
+      const left = absScrollLeft > 1 ? 1 : 0;
+      const right = remaining > 1 ? 1 : 0;
+
+      // Skip setProperty calls when the value is unchanged — scroll events can
+      // fire 60+ times per second and DOM writes are not free.
+      if (left !== lastLeft) {
+        table.style.setProperty('--lvt-shadow-left-opacity', String(left));
+        lastLeft = left;
+      }
+      if (right !== lastRight) {
+        table.style.setProperty('--lvt-shadow-right-opacity', String(right));
+        lastRight = right;
+      }
+    };
+
+    const onScrollOrResize = () => {
+      if (rafId !== null) {
+        return;
+      }
+      rafId = requestAnimationFrame(update);
+    };
+
+    update();
+    scroller.addEventListener('scroll', onScrollOrResize, { passive: true });
+    window.addEventListener('resize', onScrollOrResize, { passive: true });
+
+    // ResizeObserver catches the cases where the scroll container or the
+    // table itself changes size after mount (Mantine ScrollArea's viewport
+    // settles asynchronously, font loading reflows, parent layout changes,
+    // column resizing, etc.) — none of which fire a `scroll` or window
+    // `resize` event, so without this the opacities stay at their initial
+    // mount-time values when they were wrong.
+    let resizeObserver: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(() => {
+        onScrollOrResize();
+      });
+      resizeObserver.observe(table);
+      if (!isWindow) {
+        resizeObserver.observe(scroller as HTMLElement);
+      }
+    }
+
+    return () => {
+      scroller.removeEventListener('scroll', onScrollOrResize);
+      window.removeEventListener('resize', onScrollOrResize);
+      resizeObserver?.disconnect();
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+      }
+    };
+  }, [tableRef, enabled]);
+}

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -23,6 +23,7 @@ export {
   useKeyboardNavigation,
   useRowSelection,
   useSorting,
+  useStickyShadow,
 } from './hooks';
 export type {
   UseColumnReorderOptions,
@@ -37,4 +38,5 @@ export type {
   UseRowSelectionReturn,
   UseSortingOptions,
   UseSortingReturn,
+  UseStickyShadowOptions,
 } from './hooks';

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -46,8 +46,18 @@ export interface ListViewTableColumn<T = any> {
 
   /**
    * Whether the column is sticky (pinned).
+   *
+   * - `true` or `'left'` — pinned to the left edge of the table
+   * - `'right'` — pinned to the right edge of the table
+   * - `false` (default) — not pinned
+   *
+   * When the table scrolls horizontally, an opacity-driven gradient shadow
+   * appears on the inner edge of the **last** sticky column on each side
+   * to indicate that there is hidden content underneath. Customize via the
+   * `--lvt-shadow-color` and `--lvt-shadow-width` CSS variables, or via the
+   * `stickyColumnShadow` Styles API selector.
    */
-  sticky?: boolean;
+  sticky?: boolean | 'left' | 'right';
 
   /**
    * Text alignment for the column.
@@ -141,6 +151,7 @@ export type ListViewTableStylesNames =
   | 'emptyState'
   | 'loader'
   | 'stickyColumn'
+  | 'stickyColumnShadow'
   | 'stickyHeaderColumn';
 
 // === CSS Variables ===
@@ -156,7 +167,11 @@ export type ListViewTableCssVariables = {
     | '--list-view-cell-font-size'
     | '--list-view-cell-font-weight'
     | '--list-view-selected-row-color'
-    | '--list-view-sticky-blur';
+    | '--list-view-sticky-blur'
+    | '--lvt-shadow-color'
+    | '--lvt-shadow-width'
+    | '--lvt-shadow-left-opacity'
+    | '--lvt-shadow-right-opacity';
 };
 
 // Note: ListViewTableBaseProps, ListViewTableProps, and ListViewTableFactory

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -167,7 +167,6 @@ export type ListViewTableCssVariables = {
     | '--list-view-cell-font-size'
     | '--list-view-cell-font-weight'
     | '--list-view-selected-row-color'
-    | '--list-view-sticky-blur'
     | '--lvt-shadow-color'
     | '--lvt-shadow-width'
     | '--lvt-shadow-left-opacity'

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -151,7 +151,8 @@ export type ListViewTableStylesNames =
   | 'emptyState'
   | 'loader'
   | 'stickyColumn'
-  | 'stickyHeaderColumn';
+  | 'stickyHeaderColumn'
+  | 'scrollViewport';
 
 // === CSS Variables ===
 

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -54,8 +54,9 @@ export interface ListViewTableColumn<T = any> {
    * When the table scrolls horizontally, an opacity-driven gradient shadow
    * appears on the inner edge of the **last** sticky column on each side
    * to indicate that there is hidden content underneath. Customize via the
-   * `--lvt-shadow-color` and `--lvt-shadow-width` CSS variables, or via the
-   * `stickyColumnShadow` Styles API selector.
+   * `--lvt-shadow-color` and `--lvt-shadow-width` CSS variables, or by
+   * targeting the `stickyColumn` / `stickyHeaderColumn` Styles API
+   * selectors (the shadow is rendered as their `::after` pseudo-element).
    */
   sticky?: boolean | 'left' | 'right';
 
@@ -167,6 +168,7 @@ export type ListViewTableCssVariables = {
     | '--list-view-cell-font-size'
     | '--list-view-cell-font-weight'
     | '--list-view-selected-row-color'
+    | '--lvt-border-color'
     | '--lvt-shadow-color'
     | '--lvt-shadow-width'
     | '--lvt-shadow-left-opacity'

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -170,7 +170,8 @@ export type ListViewTableCssVariables = {
     | '--lvt-shadow-color'
     | '--lvt-shadow-width'
     | '--lvt-shadow-left-opacity'
-    | '--lvt-shadow-right-opacity';
+    | '--lvt-shadow-right-opacity'
+    | '--lvt-header-shadow-opacity';
 };
 
 // Note: ListViewTableBaseProps, ListViewTableProps, and ListViewTableFactory

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -151,7 +151,6 @@ export type ListViewTableStylesNames =
   | 'emptyState'
   | 'loader'
   | 'stickyColumn'
-  | 'stickyColumnShadow'
   | 'stickyHeaderColumn';
 
 // === CSS Variables ===


### PR DESCRIPTION
Closes #27.

Originally scoped to pinned-column visual feedback, this PR has grown into a broader pass on the **table's outer wrapper, sticky behaviors, and the Styles API surface**. All changes are additive — no breaking changes — so this targets a minor (`4.1.0`) release.

## Highlights

### Pinned columns
- `column.sticky` extended from `boolean` to `boolean | 'left' | 'right'`; `true` keeps meaning `'left'` (full backward compat).
- Subtle gradient shadow on the inner edge of the **last** sticky-left and **first** sticky-right column, fading in/out smoothly as the table scrolls horizontally. Driven by `useStickyShadow` via `requestAnimationFrame`-throttled scroll events — **no React re-renders** during scroll.
- Customization: `--lvt-shadow-color` (now actually wired up — was documented but unused before) and `--lvt-shadow-width`.

### Sticky header shadow
- Matching drop shadow under `<thead>` while it is stuck at `stickyHeaderOffset`, fading back out when sticky releases. Same UX pattern as the column shadow.
- New internal `useStickyHeaderShadow` hook drives `--lvt-header-shadow-opacity`; full shadow shape/color is customizable via `classNames.header` / `styles.header`.

### Outer wrapper border + scroll
- New `scrollProps?: { minWidth?, maxHeight? }` renders a non-scrolling outer wrapper with native horizontal/vertical scroll inside, so `withTableBorder` and `borderRadius` stay fixed at the edges during scroll — the recommended setup with sticky columns.
- New `borderRadius?: MantineRadius` (default `'sm'`) and new `borderWidth?: number | string` props on the wrapper.
- Border is now drawn on the `.root` wrapper (not on Mantine's `<table>`) so it's stable regardless of scroll. Internal viewport uses `clip-path` to clip the rounded corners — `overflow: hidden` was avoided because it would create a scroll containing block and break `position: sticky` on the thead.

### Documentation & Styles API
- Reorganized the docs TOC: scroll-related sections (Sticky Header, Pinned Columns, Horizontal Scrolling, Scroll Area) are now contiguous; **Keyboard Navigation** is a sub-section of **Row Selection**.
- Audited `ListViewTable.styles-api.ts` against the implementation — added missing modifiers (`data-with-table-border`, `data-with-scroll`, `data-dragging`/`data-resizing` on root; `data-focused` on row/headerCell), updated selector descriptions, corrected the default `--lvt-shadow-width` (8px), removed stale entries.
- README updated to mention the new shadows and border props.
- Configurator demo now exposes `borderRadius` and `borderWidth` controls.

## Test plan
- [x] Pinned columns: gradient shadow appears/fades on horizontal scroll, both light and dark
- [ ] Sticky header: drop shadow appears while stuck, fades when scrolling past the table
- [ ] `borderRadius` + `borderWidth` (0–8) render without artifacts on all 4 corners
- [ ] `scrollProps` keeps the border fixed during horizontal scroll
- [ ] `Table.ScrollContainer` still works (legacy path)
- [ ] Sticky columns + scrollProps + sticky header together render correctly
- [x] `yarn test` (47/47)
- [x] `yarn build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)