### PR TITLE
docs: show bulk actions on the selection with the core ActionBar

### DIFF
--- a/docs/demos/ListViewTable.demo.actionBarSelection.tsx
+++ b/docs/demos/ListViewTable.demo.actionBarSelection.tsx
@@ -1,0 +1,117 @@
+import { ListViewTable } from '@gfazioli/mantine-list-view-table';
+import { ActionBar, Badge, Button, Text } from '@mantine/core';
+import { MantineDemo } from '@mantinex/demo';
+import { useState } from 'react';
+import { data } from './data-files';
+
+const columns = [
+  { key: 'name', title: 'Name', sortable: true },
+  { key: 'size', title: 'Size', sortable: true, textAlign: 'right' as const },
+  {
+    key: 'modified',
+    title: 'Modified',
+    sortable: true,
+    renderCell: (row: any) => <Badge variant="light">{row.modified}</Badge>,
+  },
+];
+
+function Demo() {
+  const [selected, setSelected] = useState<React.Key[]>([]);
+  const [records, setRecords] = useState<any[]>([]);
+
+  return (
+    <>
+      <ListViewTable
+        columns={columns}
+        data={data}
+        rowKey="id"
+        selectionMode="multiple"
+        selectedRows={selected}
+        onSelectionChange={(keys, rows) => {
+          setSelected(keys);
+          setRecords(rows);
+        }}
+        withColumnBorders
+        withRowBorders
+      />
+
+      <ActionBar opened={selected.length > 0} onClose={() => setSelected([])} shadow="md">
+        <Text size="sm" fw={500}>
+          {selected.length} selected
+        </Text>
+        <Text size="sm" c="dimmed" maw={240} truncate="end">
+          {records.map((row) => row.name).join(', ')}
+        </Text>
+        <ActionBar.Divider />
+        <Button variant="default" size="compact-sm">
+          Download
+        </Button>
+        <Button variant="default" size="compact-sm">
+          Move
+        </Button>
+        <Button variant="default" size="compact-sm">
+          Delete
+        </Button>
+        <ActionBar.CloseButton />
+      </ActionBar>
+    </>
+  );
+}
+
+const code = `
+import { useState } from 'react';
+import { ListViewTable } from '@gfazioli/mantine-list-view-table';
+import { ActionBar, Button, Text } from '@mantine/core';
+import { columns } from './columns';
+import { data } from './data';
+
+function Demo() {
+  const [selected, setSelected] = useState<React.Key[]>([]);
+  const [records, setRecords] = useState<any[]>([]);
+
+  return (
+    <>
+      <ListViewTable
+        columns={columns}
+        data={data}
+        rowKey="id"
+        selectionMode="multiple"
+        selectedRows={selected}
+        onSelectionChange={(keys, rows) => {
+          setSelected(keys);
+          setRecords(rows);
+        }}
+        withColumnBorders
+        withRowBorders
+      />
+
+      <ActionBar opened={selected.length > 0} onClose={() => setSelected([])} shadow="md">
+        <Text size="sm" fw={500}>
+          {selected.length} selected
+        </Text>
+        <Text size="sm" c="dimmed" maw={240} truncate="end">
+          {records.map((row) => row.name).join(', ')}
+        </Text>
+        <ActionBar.Divider />
+        <Button variant="default" size="compact-sm">
+          Download
+        </Button>
+        <Button variant="default" size="compact-sm">
+          Move
+        </Button>
+        <Button variant="default" size="compact-sm">
+          Delete
+        </Button>
+        <ActionBar.CloseButton />
+      </ActionBar>
+    </>
+  );
+}
+`;
+
+export const actionBarSelection: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  defaultExpanded: false,
+  code: [{ fileName: 'Demo.tsx', code, language: 'tsx' }],
+};

--- a/docs/demos/index.ts
+++ b/docs/demos/index.ts
@@ -28,6 +28,7 @@ export { responsiveProps } from './ListViewTable.demo.responsiveProps';
 export { scrollArea } from './ListViewTable.demo.scrollArea';
 export { scrollContainer } from './ListViewTable.demo.scrollContainer';
 export { scrollContainerWithSticky } from './ListViewTable.demo.scrollContainerWithSticky';
+export { actionBarSelection } from './ListViewTable.demo.actionBarSelection';
 export { selection } from './ListViewTable.demo.selection';
 export { simpleEmptyText } from './ListViewTable.demo.simpleEmptyText';
 export { stickyHeader } from './ListViewTable.demo.stickyHeader';

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -130,6 +130,14 @@ For full control over the selection state, use the `selectedRows` and `onSelecti
 
 <Demo data={demos.controlledSelection} />
 
+### Bulk Actions on the Selection
+
+Mantine 9.6 added the `ActionBar` component: a fixed bottom bar built to be driven by a table selection. It pairs with `ListViewTable` without any extra API — `opened` follows the length of `selectedRows`, the actions operate on the records handed to `onSelectionChange`, and `ActionBar.CloseButton` clears the selection through `onClose`.
+
+Select a few rows below and the bar appears at the bottom of the window. It is anchored to the viewport rather than to this box, which is how a real bulk-action bar behaves; `withinPortal` and `position` are there if you need it somewhere else. Requires `@mantine/core` 9.6 or later.
+
+<Demo data={demos.actionBarSelection} />
+
 ### Keyboard Navigation
 
 When `selectionMode` is set, keyboard navigation is automatically enabled. You can also explicitly control it with the `enableKeyboardNavigation` prop.


### PR DESCRIPTION
Closes #41.

Mantine 9.6 added `ActionBar`, a fixed bottom bar built to be driven by a table selection. `ListViewTable` already exposed everything needed — `selectionMode`, `selectedRows`, `onSelectionChange` — so the two compose with **no new API**: `opened` follows the length of the selection, the buttons act on the records handed to `onSelectionChange`, and `ActionBar.CloseButton` clears it through `onClose`.

Docs only: a new demo, its registration, and a `docs.mdx` section. No change to the package.

## Design decision

The bar keeps all `ActionBar` defaults — viewport-fixed, inside a portal, `z-index: modal`. I checked what upstream does in its own `ActionBar` demo first: same thing, no containment wrapper. A bulk-action bar anchored to the window is the real behaviour, and faking containment would have meant a `transform` hack in the displayed code, which the repo's copy-paste-fidelity rule would then force on readers. The prose says where the bar appears and points at `withinPortal`/`position` for other placements.

## Verified in a browser

| Check | Result |
|---|---|
| Bar before any selection | **absent** |
| After three Cmd+Clicks | **"3 selected — File.txt, Image.png, Video.mp4"** |
| Positioning | `position: fixed`, `z-index: 200`, anchored to the viewport bottom |
| Console errors/warnings | **none** |
| TOC heading | renders as text (no backticks in the heading, so no `[object Object]`) |

## Two things worth knowing

- The demo **shows** the selected names instead of logging them. The obvious `onClick={() => console.log(records)}` fails `oxlint`, which has `no-console` as an error — and rendering the names demonstrates the second callback argument better than a console line nobody opens.
- Clicking two rows synchronously in an automated check selects only **one**. The component is controlled, so both handlers read the same pre-render `selectedRows` and the second overwrites the first. That is not a bug: a real user gets a render between clicks. Space the clicks in any probe — I wasted a round on this.

## Test plan
- [x] `yarn test` passes
- [x] `yarn docs:build` passes with `docs/.next` removed first
- [x] Selection, bar contents and positioning measured in Chrome

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a documentation demo showing bulk actions for multiple selected table rows.
  - Users can view selected-row counts and names, then download, move, delete, or clear selections.
  - Added sortable columns with modified-date indicators.

- **Documentation**
  - Documented integrating `ListViewTable` row selection with an action bar, including placement and selection-clearing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->